### PR TITLE
integrate new benchmarks for static HTTP server: binserve+wrk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v0.3.x (development version)
 
-...
+- New benchmark: static HTTP server.
 
 ## v0.3.0 (Aug 20, 2024)
 

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -291,6 +291,35 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
     except Exception as e:
         _log_cannot_load_benchmarks(server, framework, e, True)
 
+    measurement = "static_web"
+    try:
+        with open(
+            _server_framework_path(server, measurement, "parsed.json"), "r"
+        ) as fp:
+            workloads = json.load(fp)
+        versions = _server_framework_meta(server, measurement)["version"]
+        for size in workloads.keys():
+            for workload in workloads.get(size):
+                benchmarks.append(
+                    {
+                        **_benchmark_metafields(
+                            server,
+                            framework=measurement,
+                            benchmark_id=":".join(["app", measurement]),
+                        ),
+                        "config": {
+                            "size": size,
+                            "threads": workload["threads"],
+                            "threads_per_cpu": int(workload["threads"] / server.vcpus),
+                            "connections": workload["connections"],
+                            "framework_version": versions,
+                        },
+                        "score": workload["rps"],
+                    }
+                )
+    except Exception as e:
+        _log_cannot_load_benchmarks(server, framework, e, True)
+
     return benchmarks
 
 

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -276,4 +276,17 @@ benchmarks: List[Benchmark] = [
         },
         unit="bogo ops/s (real time)",
     ),
+    Benchmark(
+        benchmark_id="app:static_web",
+        name="Static web server",
+        description="Serving smaller (1-65 kb) and larger (256-512 kb) files using a static HTTP server (binserve), and benchmarking each workload (wrk) using variable number of threads and connections on the same server.",
+        framework="app",
+        measurement="static_web",
+        config_fields={
+            "threads": "Total number of threads used by wrk.",
+            "connections": "Total number of HTTP connections kept open by wrk.",
+            "framework_version": "Version number of both binserve and wrk.",
+        },
+        unit="rps",
+    ),
 ]


### PR DESCRIPTION
# Overview

<!-- brief description of what the PR does if it's not clear from the PR title -->

# Required checks before merge

- [x] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [x] PR builders passed
- [x] No red flags from coderabbit.ai
- [x] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date
- [ ] Alembic migrations are provided (or not needed)
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [x] `sc-crawler pull` was tested on all vendors and records
- [x] Human approval


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced enhanced benchmarking capabilities for static HTTP servers, allowing users to evaluate performance through new metrics and configurations.
	- Added a new benchmark entry for static web servers to provide detailed performance evaluations based on varying file sizes and configurations.

- **Documentation**
	- Updated the changelog to reflect new benchmarking enhancements and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->