### PR TITLE
DEV-337 round 2

### DIFF
--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -356,7 +356,7 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                             score / server_usrsys * (server_usrsys + client_usrsys), 2
                         )
                     if measurement.startswith("throughput"):
-                        # drop "k" suffix and multuple by 1024
+                        # drop the "k" suffix and multiply by 1024
                         size = int(record["size"][:-1]) * 1024
                         score = score * size
                     benchmarks.append(

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -315,6 +315,10 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
     for framework in SERVER_CLIENT_FRAMEWORK_MAPS.keys():
         try:
             versions = _server_framework_meta(server, framework)["version"]
+            # drop the build number at the end of the redis server version
+            if framework == "redis":
+                versions = sub(r" build=[a-zA-Z0-9]+", "", versions)
+
             records = []
             with open(
                 _server_framework_stdout_path(server, framework), newline=""

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -355,7 +355,7 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                         score = round(
                             score / server_usrsys * (server_usrsys + client_usrsys), 2
                         )
-                    if measurement.startswidth("throughput"):
+                    if measurement.startswith("throughput"):
                         # drop "k" suffix and multuple by 1024
                         size = int(record["size"][:-1]) * 1024
                         score = score * size

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 SERVER_CLIENT_FRAMEWORK_MAPS = {
     "static_web": {
-        "keys": ["size", "connections"],
+        "keys": ["size", "connections_per_vcpus"],
         "measurements": [
             "rps",
             "rps-extrapolated",
@@ -321,6 +321,8 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
             ) as f:
                 rows = csv.DictReader(f, quoting=csv.QUOTE_NONNUMERIC)
                 for row in rows:
+                    if "connections" in row.keys():
+                        row["connections_per_vcpus"] = row["connections"] / server.vcpus
                     records.append(row)
 
             framework_config = SERVER_CLIENT_FRAMEWORK_MAPS[framework]

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -284,7 +284,7 @@ benchmarks: List[Benchmark] = [
         measurement="rps",
         config_fields={
             "size": "Served file size (kb).",
-            "connections": "Total number of HTTP connections kept open by wrk.",
+            "connections_per_vcpus": "Total number of HTTP connections kept open by wrk, divided by the number of vCPUs to make it comparable with servers with different vCPU count.",
             "framework_version": "Version number of both binserve and wrk.",
         },
         unit="rps",
@@ -297,7 +297,7 @@ benchmarks: List[Benchmark] = [
         measurement="rps-extrapolated",
         config_fields={
             "size": "Served file size (kb).",
-            "connections": "Total number of HTTP connections kept open by wrk.",
+            "connections_per_vcpus": "Total number of HTTP connections kept open by wrk, divided by the number of vCPUs to make it comparable with servers with different vCPU count.",
             "framework_version": "Version number of both binserve and wrk.",
         },
         unit="rps",
@@ -310,7 +310,7 @@ benchmarks: List[Benchmark] = [
         measurement="throughput",
         config_fields={
             "size": "Served file size (kb).",
-            "connections": "Total number of HTTP connections kept open by wrk.",
+            "connections_per_vcpus": "Total number of HTTP connections kept open by wrk, divided by the number of vCPUs to make it comparable with servers with different vCPU count.",
             "framework_version": "Version number of both binserve and wrk.",
         },
         unit="bps",
@@ -323,7 +323,7 @@ benchmarks: List[Benchmark] = [
         measurement="throughput-extrapolated",
         config_fields={
             "size": "Served file size (kb).",
-            "connections": "Total number of HTTP connections kept open by wrk.",
+            "connections_per_vcpus": "Total number of HTTP connections kept open by wrk, divided by the number of vCPUs to make it comparable with servers with different vCPU count.",
             "framework_version": "Version number of both binserve and wrk.",
         },
         unit="bps",  # not bit, but byte?
@@ -336,7 +336,7 @@ benchmarks: List[Benchmark] = [
         measurement="latency",
         config_fields={
             "size": "Served file size (kb).",
-            "connections": "Total number of HTTP connections kept open by wrk.",
+            "connections_per_vcpus": "Total number of HTTP connections kept open by wrk, divided by the number of vCPUs to make it comparable with servers with different vCPU count.",
             "framework_version": "Version number of both binserve and wrk.",
         },
         unit="sec",

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -303,6 +303,32 @@ benchmarks: List[Benchmark] = [
         unit="rps",
     ),
     Benchmark(
+        benchmark_id="static_web:throughput",
+        name="Static web server+client throughput",
+        description="Serving smaller (1-65 kb) and larger (256-512 kb) files using a static HTTP server (binserve), and benchmarking each workload (wrk) using variable number of threads and connections on the same server. Throughput is calculated by multiplying the RPS with the served file size. The measured RPS is not the maximum expected server speed, as the server shared CPU with the client.",
+        framework="static_web",
+        measurement="throughput",
+        config_fields={
+            "size": "Served file size (kb).",
+            "connections": "Total number of HTTP connections kept open by wrk.",
+            "framework_version": "Version number of both binserve and wrk.",
+        },
+        unit="bps",
+    ),
+    Benchmark(
+        benchmark_id="static_web:throughput-extrapolated",
+        name="Static web server (extrapolated) throughput",
+        description="Serving smaller (1-65 kb) and larger (256-512 kb) files using a static HTTP server (binserve), and benchmarking each workload (wrk) using variable number of threads and connections on the same server. Exrapolated throughput is calculated by multiplying the exrapolated RPS with the served file size. The extrapolated RPS is based on the measured RPS adjusted by the server's and client's time spent executing in user/system mode, so trying to control for the client resource usage.",
+        framework="static_web",
+        measurement="throughput-extrapolated",
+        config_fields={
+            "size": "Served file size (kb).",
+            "connections": "Total number of HTTP connections kept open by wrk.",
+            "framework_version": "Version number of both binserve and wrk.",
+        },
+        unit="bps",  # not bit, but byte?
+    ),
+    Benchmark(
         benchmark_id="static_web:latency",
         name="Static web server latency",
         description="Serving smaller (1-65 kb) and larger (256-512 kb) files using a static HTTP server (binserve), and benchmarking each workload (wrk) using variable number of threads and connections on the same server. The average latency reported by wrk.",

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -313,7 +313,7 @@ benchmarks: List[Benchmark] = [
             "connections_per_vcpus": "Total number of HTTP connections kept open by wrk, divided by the number of vCPUs to make it comparable with servers with different vCPU count.",
             "framework_version": "Version number of both binserve and wrk.",
         },
-        unit="bps",
+        unit="Bps",
     ),
     Benchmark(
         benchmark_id="static_web:throughput-extrapolated",
@@ -326,7 +326,7 @@ benchmarks: List[Benchmark] = [
             "connections_per_vcpus": "Total number of HTTP connections kept open by wrk, divided by the number of vCPUs to make it comparable with servers with different vCPU count.",
             "framework_version": "Version number of both binserve and wrk.",
         },
-        unit="bps",  # not bit, but byte?
+        unit="Bps",
     ),
     Benchmark(
         benchmark_id="static_web:latency",

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -379,7 +379,7 @@ benchmarks: List[Benchmark] = [
             "pipeline": "The number of concurrent pipelined requests.",
             "framework_version": "Redis server version number and build information.",
         },
-        unit="sec",
+        unit="ms",
         higher_is_better=False,
     ),
 ]

--- a/src/sc_crawler/vendors/azure.py
+++ b/src/sc_crawler/vendors/azure.py
@@ -109,8 +109,8 @@ def _prices(url_params: Optional[str] = None) -> List[dict]:
         # handle rate limiting
         headers = response.headers
         remaining = headers.get("x-ms-ratelimit-remaining-retailPrices-requests", 0)
-        if int(remaining) == 0:
-            logger.debug("Retail Prices API rate limit reached, sleep for 60 seconds.")
+        if response.status_code == 429 or int(remaining) == 0:
+            logger.info("Retail Prices API rate limit reached, sleep for 60 seconds.")
             sleep(60)
         # next page
         if response.status_code == 200:


### PR DESCRIPTION
# Overview

- show "connections per vCPUs" instead of raw number of connections
- intro throughput results
- standardize redis docker version

# Required checks before merge

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [x] PR builders passed
- [x] No red flags from coderabbit.ai
- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date
- [ ] Alembic migrations are provided (or not needed)
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [x] `sc-crawler pull` was tested on all vendors and records
- [ ] Human approval


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced server benchmarking functionality with new metrics for performance analysis.
	- Introduced `connections_per_vcpus` for a more accurate understanding of connections relative to server capacity.
	- Added new benchmarks for "Static web server+client throughput" and "Static web server (extrapolated) throughput" to improve clarity and comparison across configurations.
	- Implemented a new mechanism for handling rate limits when accessing the Retail Prices API, improving robustness.

- **Bug Fixes**
	- Improved logic for throughput calculations to ensure accurate performance representation based on data size and CPU usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->