### PR TITLE
DEV-376 new stressng format

### DIFF
--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -310,7 +310,7 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                     "score": float(line.split(": ")[1]),
                 }
             )
-    except Exception as e:
+    except Exception:
         # backfill with newer method - can be dropped once we deprecate stress_ng:cpu_all
         try:
             records = []

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -312,6 +312,34 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
     except Exception as e:
         _log_cannot_load_benchmarks(server, framework, e, True)
 
+    workload = "div16"
+    try:
+        records = []
+        with open(
+            _server_framework_stdout_path(server, "stressngfull"), newline=""
+        ) as f:
+            rows = csv.reader(f)
+            for row in rows:
+                records.append(row)
+        for record in records:
+            stressng_version = _server_framework_meta(server, "stressngfull")["version"]
+            benchmarks.append(
+                {
+                    **_benchmark_metafields(
+                        server,
+                        framework="stressngfull",
+                        benchmark_id=":".join([framework, workload]),
+                    ),
+                    "config": {
+                        "cores": record[0],
+                        "framework_version": stressng_version,
+                    },
+                    "score": record[1],
+                }
+            )
+    except Exception as e:
+        _log_cannot_load_benchmarks(server, framework, e, True)
+
     for framework in SERVER_CLIENT_FRAMEWORK_MAPS.keys():
         try:
             versions = _server_framework_meta(server, framework)["version"]

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -318,7 +318,7 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
         with open(
             _server_framework_stdout_path(server, "stressngfull"), newline=""
         ) as f:
-            rows = csv.reader(f)
+            rows = csv.reader(f, quoting=csv.QUOTE_NONNUMERIC)
             for row in rows:
                 records.append(row)
         for record in records:

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -337,6 +337,22 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                     "score": record[1],
                 }
             )
+        # best single and multi core performance
+        bests = {"best1": records[0][1], "bestn": max([r[1] for r in records])}
+        for k, v in bests.items():
+            benchmarks.append(
+                {
+                    **_benchmark_metafields(
+                        server,
+                        framework="stressngfull",
+                        benchmark_id=":".join([framework, k]),
+                    ),
+                    "config": {
+                        "framework_version": stressng_version,
+                    },
+                    "score": v,
+                }
+            )
     except Exception as e:
         _log_cannot_load_benchmarks(server, framework, e, True)
 

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -277,6 +277,28 @@ benchmarks: List[Benchmark] = [
         unit="bogo ops/s (real time)",
     ),
     Benchmark(
+        benchmark_id="stress_ng:best1",
+        name="stress-ng div16 single-core",
+        description="Stress a single vCPU core with the div16 method of stress-ng, and count the total bogo operations per second based on wall clock run time.",
+        framework="stress_ng",
+        measurement="best1",
+        config_fields={
+            "framework_version": "Version number of stress-ng.",
+        },
+        unit="bogo ops/s (real time)",
+    ),
+    Benchmark(
+        benchmark_id="stress_ng:bestn",
+        name="stress-ng div16 multi-core",
+        description="Stress the CPU with the div16 method of stress-ng using a varying number of vCPU cores, and count the measured maximum total bogo operations per second based on wall clock run time.",
+        framework="stress_ng",
+        measurement="bestn",
+        config_fields={
+            "framework_version": "Version number of stress-ng.",
+        },
+        unit="bogo ops/s (real time)",
+    ),
+    Benchmark(
         benchmark_id="static_web:rps",
         name="Static web server+client speed",
         description="Serving smaller (1-65 kb) and larger (256-512 kb) files using a static HTTP server (binserve), and benchmarking each workload (wrk) using variable number of threads and connections on the same server. The measured RPS is not the maximum expected server speed, as the server shared CPU with the client.",

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -267,11 +267,23 @@ benchmarks: List[Benchmark] = [
     Benchmark(
         benchmark_id="stress_ng:cpu_all",
         name="stress-ng CPU all",
-        description="Stress the CPU with all available methods supported by stress-ng, and count the total bogo operations per second based on wall clock run time. The stress methods include bit operations, recursive calculations, integer divisions, floating point operations, matrix multiplication, stats, trigonometric, and hash functions.",
+        description="Stress the CPU with all available methods supported by stress-ng, and count the total bogo operations per second based on wall clock run time. The stress methods include bit operations, recursive calculations, integer divisions, floating point operations, matrix multiplication, stats, trigonometric, and hash functions. Note that this is to be deprecated in favor of stress_ng:div16.",
         framework="stress_ng",
         measurement="cpu_all",
         config_fields={
             "cores": "Stressing a single core or all cores.",
+            "framework_version": "Version number of stress-ng.",
+        },
+        unit="bogo ops/s (real time)",
+    ),
+    Benchmark(
+        benchmark_id="stress_ng:div16",
+        name="stress-ng div16",
+        description="Stress the CPU with the div16 method of stress-ng using a varying number of vCPU cores, and count the measured maximum total bogo operations per second based on wall clock run time.",
+        framework="stress_ng",
+        measurement="div16",
+        config_fields={
+            "cores": "Number of CPU cores stressed.",
             "framework_version": "Version number of stress-ng.",
         },
         unit="bogo ops/s (real time)",


### PR DESCRIPTION
# Overview

<!-- brief description of what the PR does if it's not clear from the PR title -->

# Required checks before merge

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date
- [ ] Alembic migrations are provided (or not needed)
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Human approval


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced new benchmarks for measuring CPU performance: "stress-ng div16," "stress-ng div16 single-core," and "stress-ng div16 multi-core."
  - Enhanced server benchmark inspections with improved data handling and error logging.

- **Deprecations**
  - Marked the previous "stress-ng CPU all" benchmark as deprecated in favor of the new benchmarks.

- **Bug Fixes**
  - Improved error handling for reading benchmark data from files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->