### PR TITLE
Upgrade to Python 3.14 (upgrade pydantic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.5.x (Apr 1, 2026)
+
+Fix(es):
+
+- Add Python 3.14 support by unpinning the `pydantic` dependency and replacing `pydantic.ImportString` with a standard
+  Python alternative in table definitions.
+
 ## v0.5.0 (Mar 23, 2026)
 
 Fix(es):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">= 3.11"
 dependencies = [
   "alembic",
   "cachier>=3.1.1",
-  "pydantic==2.9.2", # https://github.com/pydantic/pydantic/issues/10905
+  "pydantic",
   "pydantic_extra_types",
   "PyYAML",
   "requests",

--- a/src/sc_crawler/tables.py
+++ b/src/sc_crawler/tables.py
@@ -5,8 +5,9 @@ from importlib import import_module
 from types import ModuleType
 from typing import Callable, List, Optional
 
-from pydantic import ImportString, PrivateAttr
-from sqlalchemy import ForeignKeyConstraint, update
+from pydantic import PrivateAttr
+from pydantic._internal._model_construction import init_private_attributes
+from sqlalchemy import ForeignKeyConstraint, event, update
 from sqlmodel import Relationship, Session, SQLModel
 
 from .insert import insert_items
@@ -106,7 +107,7 @@ class Vendor(VendorBase, table=True):
     )
 
     # private attributes
-    _methods: Optional[ImportString[ModuleType]] = PrivateAttr(default=None)
+    _methods: Optional[ModuleType] = PrivateAttr(default=None)
     _session: Optional[Session] = PrivateAttr()
     _progress_tracker: Optional[VendorProgressTracker] = PrivateAttr(
         default=VoidProgressTracker()
@@ -126,14 +127,7 @@ class Vendor(VendorBase, table=True):
             raise ValueError("No vendor country provided")
 
     def _get_methods(self):
-        # private attributes are not (always) initialized correctly by SQLmodel
-        # e.g. the attribute is missing alltogether when loaded from DB
-        # https://github.com/tiangolo/sqlmodel/issues/149
-        try:
-            hasattr(self, "_methods")
-        except Exception:
-            self._methods = None
-        if not self._methods:
+        if not getattr(self, "_methods", None):
             vendor_module = ".".join(
                 [
                     __name__.split(".", maxsplit=1)[0],
@@ -185,7 +179,7 @@ class Vendor(VendorBase, table=True):
     @property
     def progress_tracker(self):
         """The [sc_crawler.logger.VendorProgressTracker][] to use for updating progress bars."""
-        return self._progress_tracker
+        return getattr(self, "_progress_tracker", None) or VoidProgressTracker()
 
     @progress_tracker.setter
     def progress_tracker(self, progress_tracker: VendorProgressTracker):
@@ -198,7 +192,7 @@ class Vendor(VendorBase, table=True):
     @property
     def tasks(self):
         """Reexport progress_tracker.tasks for easier access."""
-        return self._progress_tracker.tasks
+        return self.progress_tracker.tasks
 
     def log(self, message: str, level: int = logging.INFO):
         logger.log(level, self.name + ": " + message, stacklevel=2)
@@ -604,6 +598,15 @@ Region.model_rebuild()
 Zone.model_rebuild()
 Storage.model_rebuild()
 Server.model_rebuild()
+
+
+@event.listens_for(SQLModel, "load", propagate=True)
+def _init_private_attrs_on_load(target, context):
+    # When SQLAlchemy reconstructs a model instance from a DB query it bypasses
+    # __init__, leaving __pydantic_private__ = None instead of initializing it
+    # with the PrivateAttr defaults. This event listener fixes that.
+    # See: https://github.com/fastapi/sqlmodel/issues/149
+    init_private_attributes(target, None)
 
 
 def is_table(table):

--- a/src/sc_crawler/tables.py
+++ b/src/sc_crawler/tables.py
@@ -6,8 +6,7 @@ from types import ModuleType
 from typing import Callable, List, Optional
 
 from pydantic import PrivateAttr
-from pydantic._internal._model_construction import init_private_attributes
-from sqlalchemy import ForeignKeyConstraint, event, update
+from sqlalchemy import ForeignKeyConstraint, update
 from sqlmodel import Relationship, Session, SQLModel
 
 from .insert import insert_items
@@ -179,7 +178,7 @@ class Vendor(VendorBase, table=True):
     @property
     def progress_tracker(self):
         """The [sc_crawler.logger.VendorProgressTracker][] to use for updating progress bars."""
-        return getattr(self, "_progress_tracker", None) or VoidProgressTracker()
+        return self._progress_tracker
 
     @progress_tracker.setter
     def progress_tracker(self, progress_tracker: VendorProgressTracker):
@@ -192,7 +191,7 @@ class Vendor(VendorBase, table=True):
     @property
     def tasks(self):
         """Reexport progress_tracker.tasks for easier access."""
-        return self.progress_tracker.tasks
+        return self._progress_tracker.tasks
 
     def log(self, message: str, level: int = logging.INFO):
         logger.log(level, self.name + ": " + message, stacklevel=2)
@@ -598,15 +597,6 @@ Region.model_rebuild()
 Zone.model_rebuild()
 Storage.model_rebuild()
 Server.model_rebuild()
-
-
-@event.listens_for(SQLModel, "load", propagate=True)
-def _init_private_attrs_on_load(target, context):
-    # When SQLAlchemy reconstructs a model instance from a DB query it bypasses
-    # __init__, leaving __pydantic_private__ = None instead of initializing it
-    # with the PrivateAttr defaults. This event listener fixes that.
-    # See: https://github.com/fastapi/sqlmodel/issues/149
-    init_private_attributes(target, None)
 
 
 def is_table(table):


### PR DESCRIPTION
# Overview

Update `pydantic` dependency and improve private attribute initialization in `SQLModel`.

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [x] Branch is based on and up-to-date with `main`
- [x] PR has a clear title and/or brief description
- [x] PR builders passed
- [x] No red flags from coderabbit.ai
- [x] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [x] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [x] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [x] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [x] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic module loading and initialization to reduce intermittent failures during data processing.
* **Dependencies**
  * Relaxed the pydantic dependency to allow flexible versioning instead of a pinned release.
* **Documentation**
  * Added an unreleased changelog entry noting compatibility-related updates for the upcoming release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->