### PR TITLE
DEV-630 compound benchmark scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## v0.5.x (Apr 1, 2026)
 
+New feature(s):
+
+- Add workload profile scores: precomputed composite `BenchmarkScore` rows that combine multiple raw benchmark results
+  into a single normalised score per server for five predefined workload profiles (`web`, `compute`, `cache`, `ml`,
+  `cicd`), each using a weighted mix of benchmark components.
+
 Fix(es):
 
 - Add Python 3.14 support by unpinning the `pydantic` dependency and replacing `pydantic.ImportString` with a standard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.5.x (Apr 1, 2026)
+## v0.5.x (development version)
 
 New feature(s):
 

--- a/docs/add_vendor.md
+++ b/docs/add_vendor.md
@@ -9,6 +9,7 @@ Each file in the [`src/sc_crawler/vendors`](https://github.com/SpareCores/sc-cra
 3. Update `src/sc_crawler/vendors/__init__.py` to include the new vendor.
 4. Update `docs/add_vendor.md` with the credential requirements for the new vendor.
 5. Implement the `inventory` methods.
+6. Preferably also implement the related cloud-discovery tool in the `resource-tracker` package.
 
 ## Inventory methods
 

--- a/src/sc_crawler/cli.py
+++ b/src/sc_crawler/cli.py
@@ -43,6 +43,7 @@ from .table_fields import Status
 from .tables import Benchmark, ComplianceFramework, Country, Vendor, tables
 from .tables_scd import tables_scd
 from .utils import HashLevels, get_row_by_pk, hash_database, table_name_to_model
+from .workload_profile_scores import recompute_workload_profiles
 
 supported_vendors = [
     vendor[1]
@@ -806,6 +807,15 @@ def pull(
                 vendor.progress_tracker.update_vendor(step="✔")
                 session.merge(vendor)
                 session.commit()
+
+            if Records.servers in records:
+                task_id = pbars.tasks.add_task(
+                    "Computing workload profile scores", total=None
+                )
+                n = recompute_workload_profiles(session)
+                session.commit()
+                pbars.tasks.update(task_id, visible=False)
+                logger.info("%d Workload profile score(s) computed and inserted." % n)
 
         pbars.metadata.append(Text(" - " + str(datetime.now())))
 

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -551,4 +551,103 @@ benchmarks: List[Benchmark] = [
         },
         unit="tokens/second (t/s)",
     ),
+    # synthetic compound scores
+    Benchmark(
+        benchmark_id="workload_profile:web",
+        name="Workload profile: Web server",
+        description=(
+            "Precomputed compound score for web server workloads. "
+            "A weighted average of normalised scores, each normalised to [0, 1] across all servers in the dataset. "
+            "Component weights: "
+            "20% static web RPS (1 kB, 8 conn/vCPU), "
+            "15% static web throughput (256 kB, 8 conn/vCPU), "
+            "10% static web RPS (64 kB, 8 conn/vCPU), "
+            "10% static web latency (1 kB, 1 conn/vCPU), "
+            "10% Geekbench HTML5 browser (multi-core), "
+            "10% OpenSSL AES-256-CBC (16 kB blocks), "
+            "10% PassMark encryption (AES/SHA/ECDSA), "
+            "5% Geekbench text processing (multi-core), "
+            "5% PassMark string sorting, "
+            "5% PassMark cached memory reads."
+        ),
+        framework="workload_profile",
+        measurement="score",
+    ),
+    Benchmark(
+        benchmark_id="workload_profile:compute",
+        name="Workload profile: Compute heavy",
+        description=(
+            "Precomputed compound score for compute-heavy (HPC/number-crunching) workloads. "
+            "A weighted average of normalised scores, each normalised to [0, 1] across all servers in the dataset. "
+            "Component weights: "
+            "35% PassMark CPU Mark (composite), "
+            "25% stress-ng div16 single core, "
+            "20% Geekbench score (multi-core), "
+            "20% memory read bandwidth (64 MB, sc-membench)."
+        ),
+        framework="workload_profile",
+        measurement="score",
+    ),
+    Benchmark(
+        benchmark_id="workload_profile:cache",
+        name="Workload profile: Cache intensive",
+        description=(
+            "Precomputed compound score for cache/in-memory workloads (e.g. Redis/Valkey). "
+            "A weighted average of normalised scores, each normalised to [0, 1] across all servers in the dataset. "
+            "Component weights: "
+            "25% Redis RPS (pipeline=1, SET), "
+            "10% Redis RPS (pipeline=16, SET), "
+            "10% Redis latency (pipeline=1, SET), "
+            "10% PassMark memory latency (512 MB), "
+            "10% PassMark Memory Mark (composite), "
+            "10% PassMark cached memory reads, "
+            "10% memory bandwidth read (16 MB ≈ L3, bw_mem), "
+            "10% PassMark single-thread CPU, "
+            "5% PassMark in-memory DB operations."
+        ),
+        framework="workload_profile",
+        measurement="score",
+    ),
+    Benchmark(
+        benchmark_id="workload_profile:ml",
+        name="Workload profile: ML inference",
+        description=(
+            "Precomputed compound score for CPU-based machine-learning inference workloads. "
+            "A weighted average of normalised scores, each normalised to [0, 1] across all servers in the dataset. "
+            "Component weights: "
+            "20% LLM text generation (llama-7b, 128 tokens), "
+            "15% memory bandwidth read (256 MB, bw_mem), "
+            "10% LLM prompt processing (llama-7b, 512 tokens), "
+            "10% LLM text generation (gemma-2b, 128 tokens), "
+            "10% PassMark Memory Mark (composite), "
+            "10% PassMark AVX/SSE/FMA (SIMD), "
+            "10% Geekbench object detection (multi-core), "
+            "5% PassMark floating point, "
+            "5% Geekbench background blur (multi-core), "
+            "5% Geekbench structure-from-motion (multi-core)."
+        ),
+        framework="workload_profile",
+        measurement="score",
+    ),
+    Benchmark(
+        benchmark_id="workload_profile:cicd",
+        name="Workload profile: CI/CD build",
+        description=(
+            "Precomputed compound score for CI/CD build workloads. "
+            "A weighted average of normalised scores, each normalised to [0, 1] across all servers in the dataset. "
+            "Component weights: "
+            "25% Geekbench Clang compilation (multi-core), "
+            "15% PassMark single-thread CPU, "
+            "10% Geekbench Clang compilation (single-core), "
+            "10% PassMark compression, "
+            "10% PassMark integer math, "
+            "10% Geekbench text processing (multi-core), "
+            "5% stress-ng div16 best-N cores, "
+            "5% Geekbench file compression (multi-core), "
+            "5% Brotli compression (single-thread, level 0), "
+            "5% PassMark string sorting."
+        ),
+        framework="workload_profile",
+        measurement="score",
+    ),
 ]

--- a/src/sc_crawler/workload_profile_scores.py
+++ b/src/sc_crawler/workload_profile_scores.py
@@ -1,0 +1,286 @@
+"""Workload profile score computation and database persistence.
+
+This module computes precomputed compound benchmark scores for all servers
+across all vendors and stores them as synthetic BenchmarkScore rows.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import update
+from sqlmodel import Session, select
+
+from .insert import insert_items
+from .table_fields import Status
+from .tables import Benchmark, BenchmarkScore, Server, Vendor
+from .workload_profiles import WORKLOADS, BenchmarkEntry, Workload
+
+if TYPE_CHECKING:
+    pass
+
+
+def _config_matches(row_config: dict, filter_cfg: dict[str, Any] | None) -> bool:
+    """Return True if *row_config* satisfies every key in *filter_cfg*.
+
+    Numeric comparisons tolerate small floating-point differences.
+    """
+    if not filter_cfg:
+        return True
+    for key, expected in filter_cfg.items():
+        actual = row_config.get(key)
+        if actual is None:
+            return False
+        if isinstance(expected, float) and isinstance(actual, (int, float)):
+            if abs(float(actual) - expected) > 1e-6:
+                return False
+        elif isinstance(expected, int) and isinstance(actual, (int, float)):
+            if int(actual) != expected:
+                return False
+        elif actual != expected:
+            return False
+    return True
+
+
+def _collect_benchmark_ids(workload_keys: list[str]) -> list[str]:
+    """Return a deduplicated list of benchmark IDs needed for the given workloads."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for w in workload_keys:
+        for entry in WORKLOADS[w].benchmarks:
+            if entry.benchmark_id not in seen:
+                seen.add(entry.benchmark_id)
+                result.append(entry.benchmark_id)
+    return result
+
+
+def _collect_entries(workload_keys: list[str]) -> list[BenchmarkEntry]:
+    """Return a flat list of all BenchmarkEntry objects across the given workloads.
+
+    The ordering is significant: `compute_workload_scores` uses the list index
+    as a stable global entry index for min/max tracking and must receive this
+    list in the same order.
+    """
+    entries: list[BenchmarkEntry] = []
+    for w in workload_keys:
+        entries.extend(WORKLOADS[w].benchmarks)
+    return entries
+
+
+def _load_benchmark_metadata(session: Session) -> dict[str, bool]:
+    """Return a mapping of benchmark_id -> higher_is_better for all active benchmarks."""
+    rows = session.exec(
+        select(Benchmark.benchmark_id, Benchmark.higher_is_better).where(
+            Benchmark.status == Status.ACTIVE
+        )
+    ).all()
+    return {bid: bool(hib) for bid, hib in rows}
+
+
+def _load_scores(
+    session: Session,
+    benchmark_ids: list[str],
+    entries: list[BenchmarkEntry],
+    benchmark_meta: dict[str, bool],
+) -> tuple[
+    dict[tuple[str, str], dict],  # per-server data keyed by (vendor_id, server_id)
+    dict[int, tuple[float, float]],  # global (min, max) per entry index
+]:
+    """Load raw benchmark scores from the DB and build per-server structures.
+
+    For each (server, entry) pair, keeps the best score according to
+    higher_is_better when multiple rows match the same config filter.
+    """
+    if not benchmark_ids:
+        return {}, {}
+
+    rows = session.exec(
+        select(
+            BenchmarkScore.vendor_id,
+            Vendor.name,
+            BenchmarkScore.server_id,
+            Server.name,
+            BenchmarkScore.benchmark_id,
+            BenchmarkScore.config,
+            BenchmarkScore.score,
+        )
+        .join(
+            Server,
+            (Server.vendor_id == BenchmarkScore.vendor_id)
+            & (Server.server_id == BenchmarkScore.server_id),
+        )
+        .join(Vendor, Vendor.vendor_id == BenchmarkScore.vendor_id)
+        .where(
+            BenchmarkScore.status == Status.ACTIVE,
+            BenchmarkScore.benchmark_id.in_(benchmark_ids),
+        )
+    ).all()
+
+    bid_to_entries: dict[str, list[int]] = defaultdict(list)
+    for idx, e in enumerate(entries):
+        bid_to_entries[e.benchmark_id].append(idx)
+
+    per_server: dict[tuple[str, str], dict] = {}
+    entry_minmax: dict[int, tuple[float, float]] = {}
+
+    for vendor_id, vendor_name, server_id, server_name, b_id, config, score in rows:
+        if b_id not in bid_to_entries:
+            continue
+
+        score_val = float(score)
+        server_key = (vendor_id, server_id)
+
+        for entry_idx in bid_to_entries[b_id]:
+            entry = entries[entry_idx]
+            if not _config_matches(config or {}, entry.config_filter):
+                continue
+
+            if server_key not in per_server:
+                per_server[server_key] = {
+                    "vendor_id": vendor_id,
+                    "vendor_name": vendor_name,
+                    "server_id": server_id,
+                    "server_name": server_name,
+                    "scores": {},
+                }
+
+            srv = per_server[server_key]
+            higher = benchmark_meta.get(b_id, True)
+            prev = srv["scores"].get(entry_idx)
+            if prev is None:
+                srv["scores"][entry_idx] = score_val
+            else:
+                srv["scores"][entry_idx] = (
+                    max(prev, score_val) if higher else min(prev, score_val)
+                )
+
+            val = srv["scores"][entry_idx]
+            if entry_idx not in entry_minmax:
+                entry_minmax[entry_idx] = (val, val)
+            else:
+                lo, hi = entry_minmax[entry_idx]
+                entry_minmax[entry_idx] = (min(lo, val), max(hi, val))
+
+    return per_server, entry_minmax
+
+
+def _normalise(raw: float, lo: float, hi: float, higher_is_better: bool) -> float:
+    """Normalise *raw* to a [0, 1] scale given the observed global range."""
+    if hi == lo:
+        return 1.0
+    dividend = (raw - lo) if higher_is_better else (hi - raw)
+    return dividend / (hi - lo)
+
+
+def _compute_workload_score_rows(
+    per_server: dict[tuple[str, str], dict],
+    entry_minmax: dict[int, tuple[float, float]],
+    entries: list[BenchmarkEntry],
+    benchmark_meta: dict[str, bool],
+    workload_keys: list[str],
+) -> list[dict]:
+    """Compute workload-profile score rows as BenchmarkScore-compatible dicts.
+
+    Returns one dict per (vendor_id, server_id, workload_key) combination
+    that has at least one contributing benchmark score.
+    """
+    rows: list[dict] = []
+
+    for workload_key in workload_keys:
+        w_def: Workload = WORKLOADS[workload_key]
+        w_entries = w_def.benchmarks
+
+        global_start = 0
+        for w in workload_keys:
+            if w == workload_key:
+                break
+            global_start += len(WORKLOADS[w].benchmarks)
+
+        w_entry_indices = list(range(global_start, global_start + len(w_entries)))
+
+        for server_key, server_data in per_server.items():
+            weighted_sum = 0.0
+            total_weight = 0.0
+            missing_labels: list[str] = []
+
+            for local_i, global_i in enumerate(w_entry_indices):
+                entry = w_entries[local_i]
+                raw = server_data["scores"].get(global_i)
+                if raw is None or global_i not in entry_minmax:
+                    missing_labels.append(entry.label)
+                    continue
+
+                lo, hi = entry_minmax[global_i]
+                higher = benchmark_meta.get(entry.benchmark_id, True)
+                norm = _normalise(raw, lo, hi, higher)
+                weighted_sum += norm * entry.weight
+                total_weight += entry.weight
+
+            if total_weight <= 0:
+                continue
+
+            score = weighted_sum / total_weight
+
+            note: str | None = None
+            if missing_labels:
+                note = (
+                    "Partial coverage: missing component benchmark(s): "
+                    + ", ".join(missing_labels)
+                    + "."
+                )
+
+            rows.append(
+                {
+                    "vendor_id": server_data["vendor_id"],
+                    "server_id": server_data["server_id"],
+                    "benchmark_id": f"workload_profile:{workload_key}",
+                    "config": {},
+                    "score": score,
+                    "note": note,
+                }
+            )
+
+    return rows
+
+
+def recompute_workload_profiles(session: Session) -> int:
+    """Recompute workload-profile scores for all servers and persist them.
+
+    Marks all existing workload-profile BenchmarkScore rows inactive, then
+    loads all active raw benchmark scores from the database (excluding
+    workload-profile rows to avoid circularity), computes normalised composite
+    scores across all vendors, and inserts fresh rows.
+
+    Args:
+        session: Active SQLModel session connected to the crawler database.
+
+    Returns:
+        The number of workload-profile rows inserted.
+    """
+    workload_keys = list(WORKLOADS.keys())
+    benchmark_ids = _collect_benchmark_ids(workload_keys)
+    entries = _collect_entries(workload_keys)
+
+    benchmark_meta = _load_benchmark_metadata(session)
+    per_server, entry_minmax = _load_scores(
+        session, benchmark_ids, entries, benchmark_meta
+    )
+
+    if not per_server:
+        return 0
+
+    profile_rows = _compute_workload_score_rows(
+        per_server, entry_minmax, entries, benchmark_meta, workload_keys
+    )
+
+    if not profile_rows:
+        return 0
+
+    session.execute(
+        update(BenchmarkScore)
+        .where(BenchmarkScore.benchmark_id.like("workload_profile:%"))
+        .values(status=Status.INACTIVE)
+    )
+    insert_items(BenchmarkScore, profile_rows, session=session)
+    return len(profile_rows)

--- a/src/sc_crawler/workload_profile_scores.py
+++ b/src/sc_crawler/workload_profile_scores.py
@@ -240,6 +240,7 @@ def _compute_workload_score_rows(
                     "server_id": server_data["server_id"],
                     "benchmark_id": f"workload_profile:{workload_key}",
                     "config": {},
+                    "framework_version": w_def.version,
                     "score": score,
                     "note": note,
                 }

--- a/src/sc_crawler/workload_profile_scores.py
+++ b/src/sc_crawler/workload_profile_scores.py
@@ -91,6 +91,9 @@ def _load_scores(
 
     For each (server, entry) pair, keeps the best score according to
     higher_is_better when multiple rows match the same config filter.
+    The global (min, max) range per entry is derived in a second pass from
+    the finalised best scores, so intermediate values from duplicate raw rows
+    never skew normalisation.
     """
     if not benchmark_ids:
         return {}, {}
@@ -122,7 +125,6 @@ def _load_scores(
         bid_to_entries[e.benchmark_id].append(idx)
 
     per_server: dict[tuple[str, str], dict] = {}
-    entry_minmax: dict[int, tuple[float, float]] = {}
 
     for vendor_id, vendor_name, server_id, server_name, b_id, config, score in rows:
         if b_id not in bid_to_entries:
@@ -155,7 +157,9 @@ def _load_scores(
                     max(prev, score_val) if higher else min(prev, score_val)
                 )
 
-            val = srv["scores"][entry_idx]
+    entry_minmax: dict[int, tuple[float, float]] = {}
+    for server_data in per_server.values():
+        for entry_idx, val in server_data["scores"].items():
             if entry_idx not in entry_minmax:
                 entry_minmax[entry_idx] = (val, val)
             else:

--- a/src/sc_crawler/workload_profiles.py
+++ b/src/sc_crawler/workload_profiles.py
@@ -132,7 +132,7 @@ WORKLOADS: dict[str, Workload] = {
                 benchmark_id="geekbench:score",
                 weight=0.10,
                 label="Geekbench score (multi-core)",
-                config_filter={"cores": "Multi-Core Performance"},
+                config_filter={"cores": "multi"},
             ),
             # memory performance
             BenchmarkEntry(
@@ -208,7 +208,7 @@ WORKLOADS: dict[str, Workload] = {
             BenchmarkEntry(
                 benchmark_id="bw_mem",
                 weight=0.10,
-                label="Memory bandwidth (read, 16 MB ≈ L3)",
+                label="Memory bandwidth (read, 16 MB ~ L3)",
                 config_filter={"operation": "rd", "size": 16.0},
             ),
             # CPU performance benchmarks

--- a/src/sc_crawler/workload_profiles.py
+++ b/src/sc_crawler/workload_profiles.py
@@ -81,13 +81,13 @@ WORKLOADS: dict[str, Workload] = {
                 benchmark_id="geekbench:html5_browser",
                 weight=0.10,
                 label="Geekbench HTML5 browser (multi-core)",
-                config_filter={"cores": "Multi-Core Performance"},
+                config_filter={"cores": "multi"},
             ),
             BenchmarkEntry(
                 benchmark_id="geekbench:text_processing",
                 weight=0.05,
                 label="Geekbench text processing (multi-core)",
-                config_filter={"cores": "Multi-Core Performance"},
+                config_filter={"cores": "multi"},
             ),
             # SSL termination
             BenchmarkEntry(
@@ -140,7 +140,7 @@ WORKLOADS: dict[str, Workload] = {
                 benchmark_id="geekbench:score",
                 weight=0.20,
                 label="Geekbench score (multi-core)",
-                config_filter={"cores": "Multi-Core Performance"},
+                config_filter={"cores": "multi"},
             ),
             # memory performance
             BenchmarkEntry(
@@ -272,19 +272,19 @@ WORKLOADS: dict[str, Workload] = {
                 benchmark_id="geekbench:object_detection",
                 weight=0.10,
                 label="Geekbench object detection (multi-core)",
-                config_filter={"cores": "Multi-Core Performance"},
+                config_filter={"cores": "multi"},
             ),
             BenchmarkEntry(
                 benchmark_id="geekbench:background_blur",
                 weight=0.05,
                 label="Geekbench background blur (multi-core)",
-                config_filter={"cores": "Multi-Core Performance"},
+                config_filter={"cores": "multi"},
             ),
             BenchmarkEntry(
                 benchmark_id="geekbench:structure_from_motion",
                 weight=0.05,
                 label="Geekbench structure-from-motion (multi-core)",
-                config_filter={"cores": "Multi-Core Performance"},
+                config_filter={"cores": "multi"},
             ),
         ],
     ),
@@ -304,13 +304,13 @@ WORKLOADS: dict[str, Workload] = {
                 benchmark_id="geekbench:clang",
                 weight=0.25,
                 label="Geekbench Clang compilation (multi-core)",
-                config_filter={"cores": "Multi-Core Performance"},
+                config_filter={"cores": "multi"},
             ),
             BenchmarkEntry(
                 benchmark_id="geekbench:clang",
                 weight=0.10,
                 label="Geekbench Clang compilation (single-core)",
-                config_filter={"cores": "Single-Core Performance"},
+                config_filter={"cores": "single"},
             ),
             # single-core and general CPU performance
             BenchmarkEntry(
@@ -332,7 +332,7 @@ WORKLOADS: dict[str, Workload] = {
                 benchmark_id="geekbench:text_processing",
                 weight=0.10,
                 label="Geekbench text processing (multi-core)",
-                config_filter={"cores": "Multi-Core Performance"},
+                config_filter={"cores": "multi"},
             ),
             BenchmarkEntry(
                 benchmark_id="stress_ng:bestn",
@@ -344,13 +344,17 @@ WORKLOADS: dict[str, Workload] = {
                 benchmark_id="geekbench:file_compression",
                 weight=0.05,
                 label="Geekbench file compression (multi-core)",
-                config_filter={"cores": "Multi-Core Performance"},
+                config_filter={"cores": "multi"},
             ),
             BenchmarkEntry(
                 benchmark_id="compression_text:compress",
                 weight=0.05,
                 label="Brotli compression (single-thread, level 0)",
-                config_filter={"algo": "brotli", "compression_level": 0, "threads": 1},
+                config_filter={
+                    "algo": "brotli",
+                    "compression_level": 0,
+                    "cores": "single",
+                },
             ),
             # text processing/scripting
             BenchmarkEntry(

--- a/src/sc_crawler/workload_profiles.py
+++ b/src/sc_crawler/workload_profiles.py
@@ -34,6 +34,8 @@ class Workload(BaseModel):
 
     name: str
     """Short human-readable name, e.g. 'Web server'."""
+    version: str
+    """Workload profile version."""
     rationale: str
     """Explanation of which benchmarks were chosen and why."""
     benchmarks: list[BenchmarkEntry]
@@ -43,6 +45,7 @@ class Workload(BaseModel):
 WORKLOADS: dict[str, Workload] = {
     "web": Workload(
         name="Web server",
+        version="1.0",
         rationale="Primary workloads drivers are HTTP serving speed and throughput, HTML and text processing, TLS termination, and asset compression.",
         benchmarks=[
             # direct web server benchmarks
@@ -105,6 +108,7 @@ WORKLOADS: dict[str, Workload] = {
     ),
     "compute": Workload(
         name="Compute heavy",
+        version="1.0",
         rationale="Number-crunching workload augmenting raw CPU performance stressing, general CPU performance benchmarks, memory bandwidth, and pure math computation speed like floating point, integer, SIMD (AVX/SSE/FMA) operations.",
         benchmarks=[
             # raw CPU performance
@@ -163,6 +167,7 @@ WORKLOADS: dict[str, Workload] = {
     ),
     "cache": Workload(
         name="Cache intensive",
+        version="1.0",
         rationale="In-memory key-value store workload, mixing direct Redis performance metrics with memory speed and latency benchmarks, and single-core CPU performance profiles.",
         benchmarks=[
             # direct Redis benchmarks
@@ -221,6 +226,7 @@ WORKLOADS: dict[str, Workload] = {
     ),
     "llm": Workload(
         name="LLM inference",
+        version="1.0",
         rationale="VRAM and memory-bandwidth-bound LLM inference workload, using direct LLM speed benchmarks at two model sizes, and supplementing with raw memory bandwidth, SIMD, and Geekbench vision workloads that exercise ML-style pipelines.",
         benchmarks=[
             # direct LLM speed benchmarks
@@ -288,6 +294,7 @@ WORKLOADS: dict[str, Workload] = {
     ),
     "cicd": Workload(
         name="CI/CD build",
+        version="1.0",
         rationale="Build performance is driven by single- and multi-core compilation throughput, single-core CPU performance, multi-core compression and text/scripting processing.",
         benchmarks=[
             # compiling software

--- a/src/sc_crawler/workload_profiles.py
+++ b/src/sc_crawler/workload_profiles.py
@@ -54,13 +54,13 @@ WORKLOADS: dict[str, Workload] = {
             # direct web server benchmarks
             BenchmarkEntry(
                 benchmark_id="static_web:rps-extrapolated",
-                weight=0.20,
+                weight=0.25,
                 label="Static web RPS (1 kB, 8 conn/vCPU)",
                 config_filter={"size": "1k", "connections_per_vcpus": 8.0},
             ),
             BenchmarkEntry(
                 benchmark_id="static_web:rps-extrapolated",
-                weight=0.10,
+                weight=0.15,
                 label="Static web RPS (64 kB, 8 conn/vCPU)",
                 config_filter={"size": "64k", "connections_per_vcpus": 8.0},
             ),
@@ -69,12 +69,6 @@ WORKLOADS: dict[str, Workload] = {
                 weight=0.15,
                 label="Static web throughput (256 kB, 8 conn/vCPU)",
                 config_filter={"size": "256k", "connections_per_vcpus": 8.0},
-            ),
-            BenchmarkEntry(
-                benchmark_id="static_web:latency",
-                weight=0.10,
-                label="Static web latency (1 kB, 1 conn/vCPU)",
-                config_filter={"size": "1k", "connections_per_vcpus": 1.0},
             ),
             # web rendering proxies
             BenchmarkEntry(

--- a/src/sc_crawler/workload_profiles.py
+++ b/src/sc_crawler/workload_profiles.py
@@ -295,7 +295,7 @@ WORKLOADS: dict[str, Workload] = {
             Build performance is driven by single-thread speed (many build tools are serial or poorly parallelised),
             multi-core compilation throughput, compression and archiving for packaging, and text/scripting processing.
             Geekbench Clang directly compiles the Lua interpreter, providing a strong proxy for real CI workloads.
-            Research shows modern CI runners are 1.5–2× faster with higher single-thread clocks, motivating the chosen weights.
+            Research shows modern CI runners are 1.5-2x faster with higher single-thread clocks, motivating the chosen weights.
             """
         ),
         benchmarks=[

--- a/src/sc_crawler/workload_profiles.py
+++ b/src/sc_crawler/workload_profiles.py
@@ -120,28 +120,55 @@ WORKLOADS: dict[str, Workload] = {
         benchmarks=[
             # raw CPU performance
             BenchmarkEntry(
+                benchmark_id="stress_ng:bestn",
+                weight=0.15,
+                label="stress-ng div16 best-N cores",
+            ),
+            BenchmarkEntry(
                 benchmark_id="stress_ng:best1",
-                weight=0.25,
+                weight=0.10,
                 label="stress-ng div16 single core",
             ),
             # general CPU performance
             BenchmarkEntry(
                 benchmark_id="passmark:cpu_mark",
-                weight=0.35,
+                weight=0.10,
                 label="PassMark CPU Mark (composite)",
             ),
             BenchmarkEntry(
                 benchmark_id="geekbench:score",
-                weight=0.20,
+                weight=0.10,
                 label="Geekbench score (multi-core)",
-                config_filter={"cores": "multi"},
+                config_filter={"cores": "Multi-Core Performance"},
             ),
             # memory performance
             BenchmarkEntry(
-                benchmark_id="membench:bandwidth_read",
-                weight=0.20,
+                benchmark_id="bw_mem",
+                weight=0.10,
                 label="Memory bandwidth (read, 64 MB)",
-                config_filter={"size_kb": 64 * 1024},
+                config_filter={"operation": "rd", "size": 64.0},
+            ),
+            # math performance
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_floating_point_maths_test",
+                weight=0.15,
+                label="PassMark floating point",
+            ),
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_extended_instructions_test",
+                weight=0.15,
+                label="PassMark AVX/SSE/FMA (SIMD)",
+            ),
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_integer_maths_test",
+                weight=0.10,
+                label="PassMark integer math",
+            ),
+            # potential HPC workloads
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_physics_test",
+                weight=0.05,
+                label="PassMark physics simulation",
             ),
         ],
     ),

--- a/src/sc_crawler/workload_profiles.py
+++ b/src/sc_crawler/workload_profiles.py
@@ -9,7 +9,6 @@ Weights within each workload sum to 1.0.
 
 from __future__ import annotations
 
-from textwrap import dedent
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict
@@ -44,12 +43,7 @@ class Workload(BaseModel):
 WORKLOADS: dict[str, Workload] = {
     "web": Workload(
         name="Web server",
-        rationale=dedent(
-            """
-            Primary drivers: HTTP throughput, latency, TLS termination, and request-processing CPU cost.
-            NGINX research shows CPU (TLS, compression), network I/O, and memory as the three hardware axes.
-            We lean heavily on the direct static_web benchmarks and supplement with crypto, web-rendering proxies, and string handling."""
-        ),
+        rationale="Primary workloads drivers are HTTP serving speed and throughput, HTML and text processing, TLS termination, and asset compression.",
         benchmarks=[
             # direct web server benchmarks
             BenchmarkEntry(
@@ -111,12 +105,7 @@ WORKLOADS: dict[str, Workload] = {
     ),
     "compute": Workload(
         name="Compute heavy",
-        rationale=dedent(
-            """
-            HPC and number-crunching workloads stress floating point, integer, SIMD (AVX/SSE/FMA), and memory bandwidth.
-            SPEChpc research shows memory bandwidth is the bottleneck for many compute-bound codes; AVX-512 effectiveness varies by CPU generation.
-            We therefore use a broad mix of synthetic (PassMark, stress-ng) and semi-real (Geekbench ray-tracer, physics) benchmarks.""",
-        ),
+        rationale="Number-crunching workload augmenting raw CPU performance stressing, general CPU performance benchmarks, memory bandwidth, and pure math computation speed like floating point, integer, SIMD (AVX/SSE/FMA) operations.",
         benchmarks=[
             # raw CPU performance
             BenchmarkEntry(
@@ -174,13 +163,7 @@ WORKLOADS: dict[str, Workload] = {
     ),
     "cache": Workload(
         name="Cache intensive",
-        rationale=dedent(
-            """
-            Redis/Valkey is single-threaded, so single-core CPU speed and memory subsystem (latency, bandwidth, cached reads) are dominant.
-            Direct Redis benchmarks provide the strongest signal: pipeline=1 for individual ops, pipeline=16 for batching.
-            PassMark memory_latency is lower-is-better and directly predicts per-op latency.
-            """
-        ),
+        rationale="In-memory key-value store workload, mixing direct Redis performance metrics with memory speed and latency benchmarks, and single-core CPU performance profiles.",
         benchmarks=[
             # direct Redis benchmarks
             BenchmarkEntry(
@@ -236,15 +219,9 @@ WORKLOADS: dict[str, Workload] = {
             ),
         ],
     ),
-    "ml": Workload(
-        name="ML inference",
-        rationale=dedent(
-            """
-            We use direct llm_speed benchmarks at two model sizes (llama-7b for realistic production proxy, gemma-2b for a smaller model) and supplement with raw memory bandwidth, SIMD, and Geekbench vision workloads that exercise ML-style pipelines.
-            CPU-based LLM inference is *memory-bandwidth-bound*: throughput ≈ bandwidth / model_size.
-            AVX/SIMD matters for matrix operations.
-            """
-        ),
+    "llm": Workload(
+        name="LLM inference",
+        rationale="VRAM and memory-bandwidth-bound LLM inference workload, using direct LLM speed benchmarks at two model sizes, and supplementing with raw memory bandwidth, SIMD, and Geekbench vision workloads that exercise ML-style pipelines.",
         benchmarks=[
             # direct LLM speed benchmarks
             BenchmarkEntry(
@@ -311,14 +288,7 @@ WORKLOADS: dict[str, Workload] = {
     ),
     "cicd": Workload(
         name="CI/CD build",
-        rationale=dedent(
-            """
-            Build performance is driven by single-thread speed (many build tools are serial or poorly parallelised),
-            multi-core compilation throughput, compression and archiving for packaging, and text/scripting processing.
-            Geekbench Clang directly compiles the Lua interpreter, providing a strong proxy for real CI workloads.
-            Research shows modern CI runners are 1.5-2x faster with higher single-thread clocks, motivating the chosen weights.
-            """
-        ),
+        rationale="Build performance is driven by single- and multi-core compilation throughput, single-core CPU performance, multi-core compression and text/scripting processing.",
         benchmarks=[
             # compiling software
             BenchmarkEntry(

--- a/src/sc_crawler/workload_profiles.py
+++ b/src/sc_crawler/workload_profiles.py
@@ -1,0 +1,364 @@
+"""Workload profile definitions for compound benchmark scoring.
+
+Each workload profile is a weighted combination of benchmark scores that
+represents a specific real-world usage pattern. Scores are normalised to [0, 1]
+across all servers and aggregated as a weighted mean.
+
+Weights within each workload sum to 1.0.
+"""
+
+from __future__ import annotations
+
+from textwrap import dedent
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class BenchmarkEntry(BaseModel):
+    """A single benchmark component contributing to a workload profile score."""
+
+    benchmark_id: str
+    """The benchmark ID of a BenchmarkScore."""
+    weight: float
+    """Relative weight of this component. Weights within a workload sum to 1.0."""
+    label: str
+    """Human-readable description of what this component measures."""
+    config_filter: dict[str, Any] | None = None
+    """Optional filter applied to the benchmark's config JSON column."""
+
+    model_config = ConfigDict(frozen=True)
+
+
+class Workload(BaseModel):
+    """A named workload profile composed of weighted benchmark entries."""
+
+    name: str
+    """Short human-readable name, e.g. 'Web server'."""
+    rationale: str
+    """Explanation of which benchmarks were chosen and why."""
+    benchmarks: list[BenchmarkEntry]
+    """Ordered list of benchmark components with weights."""
+
+
+WORKLOADS: dict[str, Workload] = {
+    "web": Workload(
+        name="Web server",
+        rationale=dedent(
+            """
+            Primary drivers: HTTP throughput, latency, TLS termination, and request-processing CPU cost.
+            NGINX research shows CPU (TLS, compression), network I/O, and memory as the three hardware axes.
+            We lean heavily on the direct static_web benchmarks and supplement with crypto, web-rendering proxies, and string handling."""
+        ),
+        benchmarks=[
+            # direct web server benchmarks
+            BenchmarkEntry(
+                benchmark_id="static_web:rps-extrapolated",
+                weight=0.20,
+                label="Static web RPS (1 kB, 8 conn/vCPU)",
+                config_filter={"size": "1k", "connections_per_vcpus": 8.0},
+            ),
+            BenchmarkEntry(
+                benchmark_id="static_web:rps-extrapolated",
+                weight=0.10,
+                label="Static web RPS (64 kB, 8 conn/vCPU)",
+                config_filter={"size": "64k", "connections_per_vcpus": 8.0},
+            ),
+            BenchmarkEntry(
+                benchmark_id="static_web:throughput-extrapolated",
+                weight=0.15,
+                label="Static web throughput (256 kB, 8 conn/vCPU)",
+                config_filter={"size": "256k", "connections_per_vcpus": 8.0},
+            ),
+            BenchmarkEntry(
+                benchmark_id="static_web:latency",
+                weight=0.10,
+                label="Static web latency (1 kB, 1 conn/vCPU)",
+                config_filter={"size": "1k", "connections_per_vcpus": 1.0},
+            ),
+            # web rendering proxies
+            BenchmarkEntry(
+                benchmark_id="geekbench:html5_browser",
+                weight=0.10,
+                label="Geekbench HTML5 browser (multi-core)",
+                config_filter={"cores": "Multi-Core Performance"},
+            ),
+            BenchmarkEntry(
+                benchmark_id="geekbench:text_processing",
+                weight=0.05,
+                label="Geekbench text processing (multi-core)",
+                config_filter={"cores": "Multi-Core Performance"},
+            ),
+            # SSL termination
+            BenchmarkEntry(
+                benchmark_id="openssl",
+                weight=0.10,
+                label="OpenSSL AES-256-CBC (16 kB blocks)",
+                config_filter={"algo": "AES-256-CBC", "block_size": 16384},
+            ),
+            # asset compression
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_encryption_test",
+                weight=0.10,
+                label="PassMark encryption (AES/SHA/ECDSA)",
+            ),
+            # string handling
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_string_sorting_test",
+                weight=0.05,
+                label="PassMark string sorting",
+            ),
+            BenchmarkEntry(
+                benchmark_id="passmark:memory_read_cached",
+                weight=0.05,
+                label="PassMark cached memory reads",
+            ),
+        ],
+    ),
+    "compute": Workload(
+        name="Compute heavy",
+        rationale=dedent(
+            """
+            HPC and number-crunching workloads stress floating point, integer, SIMD (AVX/SSE/FMA), and memory bandwidth.
+            SPEChpc research shows memory bandwidth is the bottleneck for many compute-bound codes; AVX-512 effectiveness varies by CPU generation.
+            We therefore use a broad mix of synthetic (PassMark, stress-ng) and semi-real (Geekbench ray-tracer, physics) benchmarks.""",
+        ),
+        benchmarks=[
+            # raw CPU performance
+            BenchmarkEntry(
+                benchmark_id="stress_ng:best1",
+                weight=0.25,
+                label="stress-ng div16 single core",
+            ),
+            # general CPU performance
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_mark",
+                weight=0.35,
+                label="PassMark CPU Mark (composite)",
+            ),
+            BenchmarkEntry(
+                benchmark_id="geekbench:score",
+                weight=0.20,
+                label="Geekbench score (multi-core)",
+                config_filter={"cores": "Multi-Core Performance"},
+            ),
+            # memory performance
+            BenchmarkEntry(
+                benchmark_id="membench:bandwidth_read",
+                weight=0.20,
+                label="Memory bandwidth (read, 64 MB)",
+                config_filter={"size_kb": 64 * 1024},
+            ),
+        ],
+    ),
+    "cache": Workload(
+        name="Cache intensive",
+        rationale=dedent(
+            """
+            Redis/Valkey is single-threaded, so single-core CPU speed and memory subsystem (latency, bandwidth, cached reads) are dominant.
+            Direct Redis benchmarks provide the strongest signal: pipeline=1 for individual ops, pipeline=16 for batching.
+            PassMark memory_latency is lower-is-better and directly predicts per-op latency.
+            """
+        ),
+        benchmarks=[
+            # direct Redis benchmarks
+            BenchmarkEntry(
+                benchmark_id="redis:rps-extrapolated",
+                weight=0.25,
+                label="Redis RPS (pipeline=1, SET)",
+                config_filter={"operation": "SET", "pipeline": 1.0},
+            ),
+            BenchmarkEntry(
+                benchmark_id="redis:rps-extrapolated",
+                weight=0.10,
+                label="Redis RPS (pipeline=16, SET)",
+                config_filter={"operation": "SET", "pipeline": 16.0},
+            ),
+            BenchmarkEntry(
+                benchmark_id="redis:latency",
+                weight=0.10,
+                label="Redis latency (pipeline=1, SET)",
+                config_filter={"operation": "SET", "pipeline": 1.0},
+            ),
+            # memory performance benchmarks
+            BenchmarkEntry(
+                benchmark_id="passmark:memory_latency",
+                weight=0.10,
+                label="PassMark memory latency (512 MB)",
+            ),
+            BenchmarkEntry(
+                benchmark_id="passmark:memory_mark",
+                weight=0.10,
+                label="PassMark Memory Mark (composite)",
+            ),
+            BenchmarkEntry(
+                benchmark_id="passmark:memory_read_cached",
+                weight=0.10,
+                label="PassMark cached memory reads",
+            ),
+            BenchmarkEntry(
+                benchmark_id="bw_mem",
+                weight=0.10,
+                label="Memory bandwidth (read, 16 MB ≈ L3)",
+                config_filter={"operation": "rd", "size": 16.0},
+            ),
+            # CPU performance benchmarks
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_single_threaded_test",
+                weight=0.10,
+                label="PassMark single-thread CPU",
+            ),
+            BenchmarkEntry(
+                benchmark_id="passmark:database_operations",
+                weight=0.05,
+                label="PassMark in-memory DB operations",
+            ),
+        ],
+    ),
+    "ml": Workload(
+        name="ML inference",
+        rationale=dedent(
+            """
+            We use direct llm_speed benchmarks at two model sizes (llama-7b for realistic production proxy, gemma-2b for a smaller model) and supplement with raw memory bandwidth, SIMD, and Geekbench vision workloads that exercise ML-style pipelines.
+            CPU-based LLM inference is *memory-bandwidth-bound*: throughput ≈ bandwidth / model_size.
+            AVX/SIMD matters for matrix operations.
+            """
+        ),
+        benchmarks=[
+            # direct LLM speed benchmarks
+            BenchmarkEntry(
+                benchmark_id="llm_speed:text_generation",
+                weight=0.20,
+                label="LLM text generation (llama-7b, 128 tok)",
+                config_filter={"model": "llama-7b.Q4_K_M.gguf", "tokens": 128},
+            ),
+            BenchmarkEntry(
+                benchmark_id="llm_speed:prompt_processing",
+                weight=0.10,
+                label="LLM prompt processing (llama-7b, 512 tok)",
+                config_filter={"model": "llama-7b.Q4_K_M.gguf", "tokens": 512},
+            ),
+            BenchmarkEntry(
+                benchmark_id="llm_speed:text_generation",
+                weight=0.10,
+                label="LLM text generation (gemma-2b, 128 tok)",
+                config_filter={"model": "gemma-2b.Q4_K_M.gguf", "tokens": 128},
+            ),
+            # memory performance benchmarks
+            BenchmarkEntry(
+                benchmark_id="passmark:memory_mark",
+                weight=0.10,
+                label="PassMark Memory Mark (composite)",
+            ),
+            BenchmarkEntry(
+                benchmark_id="bw_mem",
+                weight=0.15,
+                label="Memory bandwidth (read, 256 MB)",
+                config_filter={"operation": "rd", "size": 256.0},
+            ),
+            # vector/matrix performance benchmarks
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_extended_instructions_test",
+                weight=0.10,
+                label="PassMark AVX/SSE/FMA (SIMD)",
+            ),
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_floating_point_maths_test",
+                weight=0.05,
+                label="PassMark floating point",
+            ),
+            # specific ML workloads
+            BenchmarkEntry(
+                benchmark_id="geekbench:object_detection",
+                weight=0.10,
+                label="Geekbench object detection (multi-core)",
+                config_filter={"cores": "Multi-Core Performance"},
+            ),
+            BenchmarkEntry(
+                benchmark_id="geekbench:background_blur",
+                weight=0.05,
+                label="Geekbench background blur (multi-core)",
+                config_filter={"cores": "Multi-Core Performance"},
+            ),
+            BenchmarkEntry(
+                benchmark_id="geekbench:structure_from_motion",
+                weight=0.05,
+                label="Geekbench structure-from-motion (multi-core)",
+                config_filter={"cores": "Multi-Core Performance"},
+            ),
+        ],
+    ),
+    "cicd": Workload(
+        name="CI/CD build",
+        rationale=dedent(
+            """
+            Build performance is driven by single-thread speed (many build tools are serial or poorly parallelised),
+            multi-core compilation throughput, compression and archiving for packaging, and text/scripting processing.
+            Geekbench Clang directly compiles the Lua interpreter, providing a strong proxy for real CI workloads.
+            Research shows modern CI runners are 1.5–2× faster with higher single-thread clocks, motivating the chosen weights.
+            """
+        ),
+        benchmarks=[
+            # compiling software
+            BenchmarkEntry(
+                benchmark_id="geekbench:clang",
+                weight=0.25,
+                label="Geekbench Clang compilation (multi-core)",
+                config_filter={"cores": "Multi-Core Performance"},
+            ),
+            BenchmarkEntry(
+                benchmark_id="geekbench:clang",
+                weight=0.10,
+                label="Geekbench Clang compilation (single-core)",
+                config_filter={"cores": "Single-Core Performance"},
+            ),
+            # single-core and general CPU performance
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_single_threaded_test",
+                weight=0.15,
+                label="PassMark single-thread CPU",
+            ),
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_compression_test",
+                weight=0.10,
+                label="PassMark compression",
+            ),
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_integer_maths_test",
+                weight=0.10,
+                label="PassMark integer math",
+            ),
+            BenchmarkEntry(
+                benchmark_id="geekbench:text_processing",
+                weight=0.10,
+                label="Geekbench text processing (multi-core)",
+                config_filter={"cores": "Multi-Core Performance"},
+            ),
+            BenchmarkEntry(
+                benchmark_id="stress_ng:bestn",
+                weight=0.05,
+                label="stress-ng div16 best-N cores",
+            ),
+            # asset compression
+            BenchmarkEntry(
+                benchmark_id="geekbench:file_compression",
+                weight=0.05,
+                label="Geekbench file compression (multi-core)",
+                config_filter={"cores": "Multi-Core Performance"},
+            ),
+            BenchmarkEntry(
+                benchmark_id="compression_text:compress",
+                weight=0.05,
+                label="Brotli compression (single-thread, level 0)",
+                config_filter={"algo": "brotli", "compression_level": 0, "threads": 1},
+            ),
+            # text processing/scripting
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_string_sorting_test",
+                weight=0.05,
+                label="PassMark string sorting",
+            ),
+        ],
+    ),
+}
+"""Workload profile definitions keyed by workload ID."""


### PR DESCRIPTION
# Overview

This is a first iteration of augmented workloads to test in public.

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [x] Branch is based on and up-to-date with `main`
- [x] PR has a clear title and/or brief description
- [x] PR builders passed
- [x] No red flags from coderabbit.ai
- [x] Pinged code owners for human review after all other major items in this list are completed
- [x] Human approval

Versioning, changelog, and documentation:

- [x] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [x] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [x] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [x] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workload-profile scores are now automatically computed and stored during server pulls when server data is included.
  * Added five workload-profile benchmarks: web, compute, cache, ML, and CI/CD.

* **Documentation**
  * Vendor onboarding guide updated to recommend implementing the related cloud-discovery tool.
  * Changelog updated to document the new workload-profile feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->