### PR TITLE
Convert network speed from Mbps to Gbps in OVH

### DIFF
--- a/src/sc_crawler/vendors/_ovh.py
+++ b/src/sc_crawler/vendors/_ovh.py
@@ -689,6 +689,9 @@ def inventory_servers(vendor) -> list[dict]:
         ]
         description = f"{family} ({', '.join(filter(None, description_parts))})"
 
+        network_speed = technical.get("bandwidth", {}).get("level", None)
+        network_speed_gbps = network_speed / 1000 if network_speed else None
+
         items.append(
             {
                 "vendor_id": vendor.vendor_id,
@@ -725,7 +728,7 @@ def inventory_servers(vendor) -> list[dict]:
                 "storage_size": storage_size,
                 "storage_type": storage_type,
                 "storages": storages,
-                "network_speed": technical.get("bandwidth", {}).get("level", None),
+                "network_speed": network_speed_gbps,
                 # no bundled free traffic as all traffic is unmetered
                 # https://www.ovhcloud.com/en-ie/public-cloud/prices/
                 "inbound_traffic": 0,


### PR DESCRIPTION
# Overview

Convert network speed from Mbps to Gbps in OVH.

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [x] Branch is based on and up-to-date with `main`
- [x] PR has a clear title and/or brief description
- [x] PR builders passed
- [x] No red flags from coderabbit.ai
- [x] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [x] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed network speed reporting for OVHcloud servers to correctly display bandwidth values in Gbps, ensuring accurate server specifications are reflected in the inventory.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpareCores/sc-crawler/pull/77)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->