### PR TITLE
DEV-770 update workload profiles based on the ovh-crayon hackathon

### DIFF
--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -593,7 +593,7 @@ for workload_name, workload in WORKLOADS.items():
                 "Component weights: "
                 + ", ".join(
                     [
-                        f"{benchmark.weight * 100}% {benchmark.label}"
+                        f"{int(benchmark.weight * 100)}% {benchmark.label}"
                         for benchmark in workload.benchmarks
                     ]
                 )

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -2,6 +2,7 @@ from re import sub
 from typing import List
 
 from .tables import Benchmark, ComplianceFramework, Country
+from .workload_profiles import WORKLOADS
 
 # country codes: https://en.wikipedia.org/wiki/ISO_3166-1#Codes
 # mapping: https://github.com/manumanoj0010/countrydetails/blob/master/Countrydetails/data/continents.json  # noqa: E501
@@ -577,108 +578,29 @@ benchmarks: List[Benchmark] = [
         },
         unit="tokens/second (t/s)",
     ),
-    # synthetic compound scores
-    Benchmark(
-        benchmark_id="workload_profile:web",
-        name="Workload profile: Web server",
-        category="Workload profile",
-        description=(
-            "Precomputed compound score for web server workloads. "
-            "A weighted average of normalised scores, each normalised to [0, 1] across all servers in the dataset. "
-            "Component weights: "
-            "20% static web RPS (1 kB, 8 conn/vCPU), "
-            "15% static web throughput (256 kB, 8 conn/vCPU), "
-            "10% static web RPS (64 kB, 8 conn/vCPU), "
-            "10% static web latency (1 kB, 1 conn/vCPU), "
-            "10% Geekbench HTML5 browser (multi-core), "
-            "10% OpenSSL AES-256-CBC (16 kB blocks), "
-            "10% PassMark encryption (AES/SHA/ECDSA), "
-            "5% Geekbench text processing (multi-core), "
-            "5% PassMark string sorting, "
-            "5% PassMark cached memory reads."
-        ),
-        framework="workload_profile",
-        measurement="score",
-    ),
-    Benchmark(
-        benchmark_id="workload_profile:compute",
-        name="Workload profile: Compute heavy",
-        category="Workload profile",
-        description=(
-            "Precomputed compound score for compute-heavy (HPC/number-crunching) workloads. "
-            "A weighted average of normalised scores, each normalised to [0, 1] across all servers in the dataset. "
-            "Component weights: "
-            "35% PassMark CPU Mark (composite), "
-            "25% stress-ng div16 single core, "
-            "20% Geekbench score (multi-core), "
-            "20% memory read bandwidth (64 MB, sc-membench)."
-        ),
-        framework="workload_profile",
-        measurement="score",
-    ),
-    Benchmark(
-        benchmark_id="workload_profile:cache",
-        name="Workload profile: Cache intensive",
-        category="Workload profile",
-        description=(
-            "Precomputed compound score for cache/in-memory workloads (e.g. Redis/Valkey). "
-            "A weighted average of normalised scores, each normalised to [0, 1] across all servers in the dataset. "
-            "Component weights: "
-            "25% Redis RPS (pipeline=1, SET), "
-            "10% Redis RPS (pipeline=16, SET), "
-            "10% Redis latency (pipeline=1, SET), "
-            "10% PassMark memory latency (512 MB), "
-            "10% PassMark Memory Mark (composite), "
-            "10% PassMark cached memory reads, "
-            "10% memory bandwidth read (16 MB ≈ L3, bw_mem), "
-            "10% PassMark single-thread CPU, "
-            "5% PassMark in-memory DB operations."
-        ),
-        framework="workload_profile",
-        measurement="score",
-    ),
-    Benchmark(
-        benchmark_id="workload_profile:ml",
-        name="Workload profile: ML inference",
-        category="Workload profile",
-        description=(
-            "Precomputed compound score for CPU-based machine-learning inference workloads. "
-            "A weighted average of normalised scores, each normalised to [0, 1] across all servers in the dataset. "
-            "Component weights: "
-            "20% LLM text generation (llama-7b, 128 tokens), "
-            "15% memory bandwidth read (256 MB, bw_mem), "
-            "10% LLM prompt processing (llama-7b, 512 tokens), "
-            "10% LLM text generation (gemma-2b, 128 tokens), "
-            "10% PassMark Memory Mark (composite), "
-            "10% PassMark AVX/SSE/FMA (SIMD), "
-            "10% Geekbench object detection (multi-core), "
-            "5% PassMark floating point, "
-            "5% Geekbench background blur (multi-core), "
-            "5% Geekbench structure-from-motion (multi-core)."
-        ),
-        framework="workload_profile",
-        measurement="score",
-    ),
-    Benchmark(
-        benchmark_id="workload_profile:cicd",
-        name="Workload profile: CI/CD build",
-        category="Workload profile",
-        description=(
-            "Precomputed compound score for CI/CD build workloads. "
-            "A weighted average of normalised scores, each normalised to [0, 1] across all servers in the dataset. "
-            "Component weights: "
-            "25% Geekbench Clang compilation (multi-core), "
-            "15% PassMark single-thread CPU, "
-            "10% Geekbench Clang compilation (single-core), "
-            "10% PassMark compression, "
-            "10% PassMark integer math, "
-            "10% Geekbench text processing (multi-core), "
-            "5% stress-ng div16 best-N cores, "
-            "5% Geekbench file compression (multi-core), "
-            "5% Brotli compression (single-thread, level 0), "
-            "5% PassMark string sorting."
-        ),
-        framework="workload_profile",
-        measurement="score",
-    ),
 ]
+
+# dynamically add synthetic compound/augmented workloads
+for workload_name, workload in WORKLOADS.items():
+    benchmarks.append(
+        Benchmark(
+            benchmark_id=f"workload_profile:{workload_name}",
+            name=f"Workload profile: {workload.name}",
+            category="Workload profile",
+            description=(
+                f"Precomputed compound score for {workload.name} workloads. "
+                "A weighted average of normalised scores, each normalised to [0, 1] across all servers in the dataset. "
+                "Component weights: "
+                + ", ".join(
+                    [
+                        f"{benchmark.weight * 100}% {benchmark.label}"
+                        for benchmark in workload.benchmarks
+                    ]
+                )
+                + ". Rationale for component selection: "
+                + workload.rationale
+            ),
+            framework="workload_profile",
+            measurement="score",
+        )
+    )

--- a/src/sc_crawler/workload_profiles.py
+++ b/src/sc_crawler/workload_profiles.py
@@ -287,7 +287,6 @@ WORKLOADS: dict[str, Workload] = {
             ),
         ],
     ),
-
     "llm": Workload(
         name="Multimodal LLM Inference",
         version="1.0",

--- a/src/sc_crawler/workload_profiles.py
+++ b/src/sc_crawler/workload_profiles.py
@@ -44,7 +44,7 @@ class Workload(BaseModel):
 
 WORKLOADS: dict[str, Workload] = {
     "web": Workload(
-        name="Web server",
+        name="Web Server",
         version="1.0",
         rationale="Primary workloads drivers are HTTP serving speed and throughput, HTML and text processing, TLS termination, and asset compression.",
         benchmarks=[
@@ -107,7 +107,7 @@ WORKLOADS: dict[str, Workload] = {
         ],
     ),
     "compute": Workload(
-        name="Compute heavy",
+        name="Compute Heavy Applications",
         version="1.0",
         rationale="Number-crunching workload augmenting raw CPU performance stressing, general CPU performance benchmarks, memory bandwidth, and pure math computation speed like floating point, integer, SIMD (AVX/SSE/FMA) operations.",
         benchmarks=[
@@ -166,7 +166,7 @@ WORKLOADS: dict[str, Workload] = {
         ],
     ),
     "cache": Workload(
-        name="Cache intensive",
+        name="Cache Intensive",
         version="1.0",
         rationale="In-memory key-value store workload, mixing direct Redis performance metrics with memory speed and latency benchmarks, and single-core CPU performance profiles.",
         benchmarks=[
@@ -293,7 +293,7 @@ WORKLOADS: dict[str, Workload] = {
         ],
     ),
     "cicd": Workload(
-        name="CI/CD build",
+        name="CI/CD Build",
         version="1.0",
         rationale="Build performance is driven by single- and multi-core compilation throughput, single-core CPU performance, multi-core compression and text/scripting processing.",
         benchmarks=[

--- a/src/sc_crawler/workload_profiles.py
+++ b/src/sc_crawler/workload_profiles.py
@@ -227,9 +227,9 @@ WORKLOADS: dict[str, Workload] = {
         ],
     ),
     "llm": Workload(
-        name="LLM inference",
+        name="Multimodal LLM Inference",
         version="1.0",
-        rationale="VRAM and memory-bandwidth-bound LLM inference workload, using direct LLM speed benchmarks at two model sizes, and supplementing with raw memory bandwidth, SIMD, and Geekbench vision workloads that exercise ML-style pipelines.",
+        rationale="VRAM and memory-bandwidth-bound LLM inference workload, using direct LLM speed benchmarks at two model sizes, and supplementing with raw memory bandwidth, SIMD, and Geekbench computer vision workloads that exercise ML-style pipelines.",
         benchmarks=[
             # direct LLM speed benchmarks
             BenchmarkEntry(

--- a/src/sc_crawler/workload_profiles.py
+++ b/src/sc_crawler/workload_profiles.py
@@ -226,6 +226,68 @@ WORKLOADS: dict[str, Workload] = {
             ),
         ],
     ),
+    "database": Workload(
+        name="Relational Database",
+        version="1.0",
+        rationale="Relational database workload (PostgreSQL, MySQL, transactional OLTP). Direct DB operation throughput is the primary driver, followed by memory latency for index lookups and buffer pool access, memory subsystem performance for working-set throughput, and single-thread CPU for query execution.",
+        benchmarks=[
+            BenchmarkEntry(
+                benchmark_id="passmark:database_operations",
+                weight=0.35,
+                label="PassMark in-memory DB operations",
+            ),
+            BenchmarkEntry(
+                benchmark_id="passmark:memory_latency",
+                weight=0.30,
+                label="PassMark memory latency (512 MB)",
+            ),
+            BenchmarkEntry(
+                benchmark_id="passmark:memory_mark",
+                weight=0.20,
+                label="PassMark Memory Mark (composite)",
+            ),
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_single_threaded_test",
+                weight=0.15,
+                label="PassMark single-thread CPU",
+            ),
+        ],
+    ),
+    "data_analysis": Workload(
+        name="Data Analysis",
+        version="1.0",
+        rationale="Data analysis and ETL workloads are memory-bandwidth-bound and CPU-throughput-driven. The profile combines general CPU performance and memory bandwidth/latency as the primary drivers, supplemented by single-core compression speed as a proxy for serialisation-heavy ETL tasks.",
+        benchmarks=[
+            BenchmarkEntry(
+                benchmark_id="passmark:cpu_mark",
+                weight=0.30,
+                label="PassMark CPU Mark (composite)",
+            ),
+            BenchmarkEntry(
+                # TODO migrate to membench with scope:RAM
+                benchmark_id="bw_mem",
+                weight=0.30,
+                label="Memory bandwidth (read, 64 MB)",
+                config_filter={"operation": "rd", "size": 64.0},
+            ),
+            BenchmarkEntry(
+                benchmark_id="passmark:memory_mark",
+                weight=0.25,
+                label="PassMark Memory Mark (composite)",
+            ),
+            BenchmarkEntry(
+                benchmark_id="compression_text:compress",
+                weight=0.15,
+                label="Gzip compression (single-thread, level 5)",
+                config_filter={
+                    "algo": "gzip",
+                    "compression_level": 5,
+                    "cores": "single",
+                },
+            ),
+        ],
+    ),
+
     "llm": Workload(
         name="Multimodal LLM Inference",
         version="1.0",

--- a/src/sc_crawler/workload_profiles.py
+++ b/src/sc_crawler/workload_profiles.py
@@ -136,6 +136,7 @@ WORKLOADS: dict[str, Workload] = {
             ),
             # memory performance
             BenchmarkEntry(
+                # TODO migrate to membench with scope:RAM
                 benchmark_id="bw_mem",
                 weight=0.10,
                 label="Memory bandwidth (read, 64 MB)",
@@ -206,6 +207,7 @@ WORKLOADS: dict[str, Workload] = {
                 label="PassMark cached memory reads",
             ),
             BenchmarkEntry(
+                # TODO migrate to membench with scope:RAM
                 benchmark_id="bw_mem",
                 weight=0.10,
                 label="Memory bandwidth (read, 16 MB ~ L3)",
@@ -255,6 +257,7 @@ WORKLOADS: dict[str, Workload] = {
                 label="PassMark Memory Mark (composite)",
             ),
             BenchmarkEntry(
+                # TODO migrate to membench with scope:RAM
                 benchmark_id="bw_mem",
                 weight=0.15,
                 label="Memory bandwidth (read, 256 MB)",
@@ -272,6 +275,7 @@ WORKLOADS: dict[str, Workload] = {
                 label="PassMark floating point",
             ),
             # specific ML workloads
+            # TODO split this into Comptuer Vision workload
             BenchmarkEntry(
                 benchmark_id="geekbench:object_detection",
                 weight=0.10,


### PR DESCRIPTION
# Overview

Update the augmented workload definitions based on what we have discussed at the OVH/SoftwareOne hackathon -- along with DRY-ing up the human-friendly definitions.

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [x] Branch is based on and up-to-date with `main`
- [x] PR has a clear title and/or brief description
- [x] PR builders passed
- [x] No red flags from coderabbit.ai
- [x] Pinged code owners for human review after all other major items in this list are completed
- [x] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [x] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added two new workload profiles: `database` and `data_analysis`, with their own benchmark configurations and weightings.
  * Updated display names for existing workload profiles (`web`, `compute`, `cache`, `cicd`).
  * Enhanced workload profile descriptions with updated rationale information and improved benchmark generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpareCores/sc-crawler/pull/78)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->