### PR TITLE
DEV-776 helpers to add/get metadata in the crawler DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.5.x (development)
+
+New feature(s):
+
+- Add `metadata` command to read and write database metadata.
+
 ## v0.5.1 (Apr 22, 2026)
 
 New feature(s):

--- a/src/sc_crawler/cli.py
+++ b/src/sc_crawler/cli.py
@@ -29,7 +29,7 @@ from rich.progress import (
 )
 from rich.table import Table
 from rich.text import Text
-from sqlalchemy import create_mock_engine, text
+from sqlalchemy import Engine, create_mock_engine, inspect, text
 from sqlalchemy.engine.reflection import Inspector
 from sqlalchemy.sql import quoted_name
 from sqlmodel import Session, create_engine, select, update
@@ -273,12 +273,21 @@ def metadata_set(
         session.commit()
 
 
+def _assert_metadata(engine: Engine):
+    """Assert that the metadata table exists in the database."""
+    if not inspect(engine).has_table("_metadata"):
+        print("Metadata table not found in database.")
+        raise typer.Exit(code=1)
+    return True
+
+
 @metadata_app.command(name="get")
 def metadata_get(
     connection_string: options.connection_string = "sqlite:///sc-data-all.db",
 ):
     """Print all metadata key/value pairs stored in the database."""
     engine = create_engine(connection_string)
+    _assert_metadata(engine)
     with Session(engine) as session:
         rows = session.exec(select(Metadata)).all()
     table = Table("Key", "Value")
@@ -294,6 +303,7 @@ def metadata_delete(
 ):
     """Delete one or more metadata entries by key."""
     engine = create_engine(connection_string)
+    _assert_metadata(engine)
     with Session(engine) as session:
         for key in keys:
             row = session.get(Metadata, key)

--- a/src/sc_crawler/cli.py
+++ b/src/sc_crawler/cli.py
@@ -11,7 +11,6 @@ from json import dumps, loads
 from os import environ
 from pathlib import Path
 from re import sub
-from shlex import split as shlex_split
 from types import SimpleNamespace
 from typing import List, Optional
 
@@ -236,24 +235,19 @@ def autogenerate(
 
 @metadata_app.command(name="set")
 def metadata_set(
-    connection_string: options.connection_string = "sqlite:///sc-data-all.db",
     entries: Annotated[
         Optional[List[str]],
-        typer.Option(
-            "--entry",
-            help=(
-                "Metadata as key=value pair(s). Can be repeated, or pass multiple "
-                "space-separated pairs in one value (quote values that contain spaces), "
-                "e.g. --entry publisher='Spare Cores' --entry 'license=BSL change_license=CC-BY-4.0'."
-            ),
+        typer.Argument(
+            help="Metadata as key=value pairs, e.g. publisher='Spare Cores' license=BSL.",
         ),
     ] = None,
+    connection_string: options.connection_string = "sqlite:///sc-data-all.db",
 ):
     """Write metadata key/value pairs into the database.
 
     Always sets `sc_crawler_version` and `published_at`. When running in a GitHub
     Actions workflow, also sets `published_by` to the GitHub Actions run URL.
-    Additional key/value pairs can be passed via `--entry key=value`.
+    Additional key/value pairs can be passed as positional arguments.
     """
     engine = create_engine(connection_string)
     Metadata.metadata.create_all(engine, tables=[Metadata.__table__])
@@ -270,10 +264,9 @@ def metadata_set(
                 value="{}/{}/actions/runs/{}".format(*[environ[v] for v in gh_vars]),
             )
         )
-    for entry in entries or []:
-        for item in shlex_split(entry):
-            key, _, value = item.partition("=")
-            rows.append(Metadata(key=key.strip(), value=value.strip()))
+    for item in entries or []:
+        key, _, value = item.partition("=")
+        rows.append(Metadata(key=key.strip(), value=value.strip()))
     with Session(engine) as session:
         for row in rows:
             session.merge(row)
@@ -296,16 +289,17 @@ def metadata_get(
 
 @metadata_app.command(name="delete")
 def metadata_delete(
-    key: Annotated[str, typer.Argument(help="Metadata key to delete.")],
+    keys: Annotated[List[str], typer.Argument(help="Metadata key(s) to delete.")],
     connection_string: options.connection_string = "sqlite:///sc-data-all.db",
 ):
-    """Delete a single metadata entry by key."""
+    """Delete one or more metadata entries by key."""
     engine = create_engine(connection_string)
     with Session(engine) as session:
-        row = session.get(Metadata, key)
-        if row is None:
-            raise typer.BadParameter(f"Key {key!r} not found in metadata.")
-        session.delete(row)
+        for key in keys:
+            row = session.get(Metadata, key)
+            if row is None:
+                raise typer.BadParameter(f"Key {key!r} not found in metadata.")
+            session.delete(row)
         session.commit()
 
 

--- a/src/sc_crawler/cli.py
+++ b/src/sc_crawler/cli.py
@@ -35,6 +35,7 @@ from sqlalchemy.sql import quoted_name
 from sqlmodel import Session, create_engine, select, update
 from typing_extensions import Annotated
 
+from . import __version__
 from . import vendors as vendors_module
 from .alembic_helpers import alembic_cfg, get_revision
 from .insert import insert_items
@@ -42,7 +43,7 @@ from .logger import ProgressPanel, ScRichHandler, VendorProgressTracker, logger
 from .lookup import benchmarks, compliance_frameworks, countries
 from .sentry import before_send
 from .table_fields import Status
-from .tables import Benchmark, ComplianceFramework, Country, Vendor, tables
+from .tables import Benchmark, ComplianceFramework, Country, Metadata, Vendor, tables
 from .tables_scd import tables_scd
 from .utils import HashLevels, get_row_by_pk, hash_database, table_name_to_model
 from .workload_profile_scores import recompute_workload_profiles
@@ -227,6 +228,47 @@ def autogenerate(
         command.revision(
             alembic_cfg(connection=connection), autogenerate=True, message=message
         )
+
+
+@alembic_app.command()
+def release(
+    connection_string: options.connection_string = "sqlite:///sc-data-all.db",
+    set_metadata: Annotated[
+        Optional[List[str]],
+        typer.Option(
+            "--set",
+            help="Additional metadata as key=value pairs, e.g. --set publisher='Spare Cores Kft'.",
+        ),
+    ] = None,
+):
+    """Inject a _metadata table to the database with optional key/value pairs.
+
+    By default, it will set the sc-crawler version and published_at date.
+    When running in a GitHub Actions workflow, it will also set the published_by to the GitHub Actions run URL.
+    Additional key/value pairs can be passed via --set key=value.
+    """
+    engine = create_engine(connection_string)
+    Metadata.metadata.create_all(engine, tables=[Metadata.__table__])
+    now = datetime.now(UTC)
+    rows = [
+        Metadata(key="sc_crawler_version", value=__version__),
+        Metadata(key="published_at", value=str(now)),
+    ]
+    gh_vars = ("GITHUB_SERVER_URL", "GITHUB_REPOSITORY", "GITHUB_RUN_ID")
+    if all(v in environ for v in gh_vars):
+        rows.append(
+            Metadata(
+                key="published_by",
+                value="{}/{}/actions/runs/{}".format(*[environ[v] for v in gh_vars]),
+            )
+        )
+    for item in set_metadata or []:
+        key, _, value = item.partition("=")
+        rows.append(Metadata(key=key.strip(), value=value.strip()))
+    with Session(engine) as session:
+        for row in rows:
+            session.merge(row)
+        session.commit()
 
 
 @cli.command(name="hash")

--- a/src/sc_crawler/cli.py
+++ b/src/sc_crawler/cli.py
@@ -11,6 +11,7 @@ from json import dumps, loads
 from os import environ
 from pathlib import Path
 from re import sub
+from shlex import split as shlex_split
 from types import SimpleNamespace
 from typing import List, Optional
 
@@ -81,6 +82,9 @@ alembic_app = typer.Typer()
 cli.add_typer(
     alembic_app, name="schemas", help="Database migration utilities using Alembic."
 )
+
+metadata_app = typer.Typer()
+cli.add_typer(metadata_app, name="metadata", help="Read and write database metadata.")
 
 options = SimpleNamespace(
     connection_string=Annotated[
@@ -230,22 +234,26 @@ def autogenerate(
         )
 
 
-@alembic_app.command()
-def release(
+@metadata_app.command(name="set")
+def metadata_set(
     connection_string: options.connection_string = "sqlite:///sc-data-all.db",
-    set_metadata: Annotated[
+    entries: Annotated[
         Optional[List[str]],
         typer.Option(
-            "--set",
-            help="Additional metadata as key=value pairs, e.g. --set publisher='Spare Cores Kft'.",
+            "--entry",
+            help=(
+                "Metadata as key=value pair(s). Can be repeated, or pass multiple "
+                "space-separated pairs in one value (quote values that contain spaces), "
+                "e.g. --entry publisher='Spare Cores' --entry 'license=BSL change_license=CC-BY-4.0'."
+            ),
         ),
     ] = None,
 ):
-    """Inject a _metadata table to the database with optional key/value pairs.
+    """Write metadata key/value pairs into the database.
 
-    By default, it will set the sc-crawler version and published_at date.
-    When running in a GitHub Actions workflow, it will also set the published_by to the GitHub Actions run URL.
-    Additional key/value pairs can be passed via --set key=value.
+    Always sets `sc_crawler_version` and `published_at`. When running in a GitHub
+    Actions workflow, also sets `published_by` to the GitHub Actions run URL.
+    Additional key/value pairs can be passed via `--entry key=value`.
     """
     engine = create_engine(connection_string)
     Metadata.metadata.create_all(engine, tables=[Metadata.__table__])
@@ -262,12 +270,42 @@ def release(
                 value="{}/{}/actions/runs/{}".format(*[environ[v] for v in gh_vars]),
             )
         )
-    for item in set_metadata or []:
-        key, _, value = item.partition("=")
-        rows.append(Metadata(key=key.strip(), value=value.strip()))
+    for entry in entries or []:
+        for item in shlex_split(entry):
+            key, _, value = item.partition("=")
+            rows.append(Metadata(key=key.strip(), value=value.strip()))
     with Session(engine) as session:
         for row in rows:
             session.merge(row)
+        session.commit()
+
+
+@metadata_app.command(name="get")
+def metadata_get(
+    connection_string: options.connection_string = "sqlite:///sc-data-all.db",
+):
+    """Print all metadata key/value pairs stored in the database."""
+    engine = create_engine(connection_string)
+    with Session(engine) as session:
+        rows = session.exec(select(Metadata)).all()
+    table = Table("Key", "Value")
+    for row in rows:
+        table.add_row(row.key, row.value)
+    Console().print(table)
+
+
+@metadata_app.command(name="delete")
+def metadata_delete(
+    key: Annotated[str, typer.Argument(help="Metadata key to delete.")],
+    connection_string: options.connection_string = "sqlite:///sc-data-all.db",
+):
+    """Delete a single metadata entry by key."""
+    engine = create_engine(connection_string)
+    with Session(engine) as session:
+        row = session.get(Metadata, key)
+        if row is None:
+            raise typer.BadParameter(f"Key {key!r} not found in metadata.")
+        session.delete(row)
         session.commit()
 
 

--- a/src/sc_crawler/tables.py
+++ b/src/sc_crawler/tables.py
@@ -611,3 +611,14 @@ def is_table(table):
 
 tables: List[SQLModel] = [o for o in globals().values() if is_table(o)]
 """List of all SQLModel (table) models."""
+
+
+from sqlmodel import Field  # noqa: E402
+
+
+class Metadata(SQLModel, table=True):
+    """Key/value metadata table for database release information."""
+
+    __tablename__ = "_metadata"
+    key: str = Field(primary_key=True)
+    value: str


### PR DESCRIPTION
# Overview

<!-- brief description of what the PR does if it's not clear from the PR title -->

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [x] Branch is based on and up-to-date with `main`
- [x] PR has a clear title and/or brief description
- [x] PR builders passed
- [x] No red flags from coderabbit.ai
- [x] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [x] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a metadata command with three subcommands for managing stored metadata:
    * set: write or merge metadata entries, automatically recording the crawler version and publication timestamp (and optionally publisher)
    * get: display all stored metadata in a formatted table
    * delete: remove one or more metadata entries by key
  * Introduced persistent metadata storage for these entries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpareCores/sc-crawler/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->