### PR TITLE
Add RAM scope benchmarks for membench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 dist/
 *.egg-info/
 .python-version
+uv.lock
 
 # Installer logs
 pip-log.txt
@@ -22,6 +23,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/_build/
+docs/reference/
 
 # Temp linters
 flycheck_*
@@ -33,3 +35,15 @@ sc-data-all.db
 # IDE
 .vscode/
 .idea/
+
+# Test artifacts
+*.txt
+*.json
+*.sql
+*.log
+
+# Documentation
+site/
+
+# MacOS
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 New feature(s):
 
 - Add `metadata` command to read and write database metadata.
+- Add `membench` benchmark scores with `scope: RAM` config for the first working set size per operation that exceeds total L3 cache.
 
 ## v0.5.1 (Apr 22, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 New feature(s):
 
 - Add `metadata` command to read and write database metadata.
-- Add `membench` benchmark scores with `scope: RAM` config for the first working set size per operation that exceeds total L3 cache.
+- Add `membench` benchmark scores with `scope: RAM` config for the first working set size per operation that exceeds total CPU cache (L3, else L2, else L1d).
 
 ## v0.5.1 (Apr 22, 2026)
 

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -612,7 +612,8 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                         }
                     )
                     if (
-                        size_kb > server.cpu_l3_cache_total
+                        server.cpu_l3_cache_total is not None
+                        and size_kb > server.cpu_l3_cache_total
                         and not ram_scope_dict[operation]
                     ):
                         ram_scope_dict[operation] = True
@@ -643,7 +644,8 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                         }
                     )
                     if (
-                        size_kb > server.cpu_l3_cache_total
+                        server.cpu_l3_cache_total is not None
+                        and size_kb > server.cpu_l3_cache_total
                         and not ram_scope_dict[operation]
                     ):
                         ram_scope_dict[operation] = True

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -592,6 +592,7 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                 "copy": False,
                 "latency": False,
             }
+            cpu_cache_total_kib = _first_cpu_cache_total_kib(server)
             for row in reader:
                 operation = row["operation"]
                 size_kb = int(float(row["size_kb"]))
@@ -612,8 +613,8 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                         }
                     )
                     if (
-                        server.cpu_l3_cache_total is not None
-                        and size_kb > server.cpu_l3_cache_total
+                        cpu_cache_total_kib is not None
+                        and size_kb > cpu_cache_total_kib
                         and not ram_scope_dict[operation]
                     ):
                         ram_scope_dict[operation] = True
@@ -644,8 +645,8 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                         }
                     )
                     if (
-                        server.cpu_l3_cache_total is not None
-                        and size_kb > server.cpu_l3_cache_total
+                        cpu_cache_total_kib is not None
+                        and size_kb > cpu_cache_total_kib
                         and not ram_scope_dict[operation]
                     ):
                         ram_scope_dict[operation] = True
@@ -962,6 +963,18 @@ def _l123_cache(lscpu: dict, level: int):
         return cache
     else:
         raise ValueError("Not known cache level.")
+
+
+def _first_cpu_cache_total_kib(server: "Server") -> int | None:
+    """First available total cache size in KiB (L3, then L2, then L1d)."""
+    for cache_total in (
+        server.cpu_l3_cache_total,
+        server.cpu_l2_cache_total,
+        server.cpu_l1d_cache_total,
+    ):
+        if cache_total is not None:
+            return cache_total
+    return None
 
 
 def _dropna(text: str) -> str:

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -586,6 +586,12 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
     try:
         with open(_server_framework_stdout_path(server, framework), newline="") as fp:
             reader = csv.DictReader(fp)
+            ram_scope_dict = {
+                "read": False,
+                "write": False,
+                "copy": False,
+                "latency": False,
+            }
             for row in reader:
                 operation = row["operation"]
                 size_kb = int(float(row["size_kb"]))
@@ -605,6 +611,22 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                             "score": score,
                         }
                     )
+                    if (
+                        size_kb > server.cpu_l3_cache_total
+                        and not ram_scope_dict[operation]
+                    ):
+                        ram_scope_dict[operation] = True
+                        benchmarks.append(
+                            {
+                                **_benchmark_metafields(
+                                    server,
+                                    framework=framework,
+                                    benchmark_id="membench:latency",
+                                ),
+                                "config": {"scope": "RAM"},
+                                "score": score,
+                            }
+                        )
                 elif operation in ("read", "write", "copy"):
                     score = float(row["bandwidth_mb_s"])
                     if score == 0:
@@ -620,6 +642,22 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                             "score": score,
                         }
                     )
+                    if (
+                        size_kb > server.cpu_l3_cache_total
+                        and not ram_scope_dict[operation]
+                    ):
+                        ram_scope_dict[operation] = True
+                        benchmarks.append(
+                            {
+                                **_benchmark_metafields(
+                                    server,
+                                    framework=framework,
+                                    benchmark_id=f"membench:bandwidth_{operation}",
+                                ),
+                                "config": {"scope": "RAM"},
+                                "score": score,
+                            }
+                        )
     except Exception as e:
         _log_cannot_load_benchmarks(server, framework, e, True)
 

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -592,7 +592,11 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                 "copy": False,
                 "latency": False,
             }
-            cpu_cache_total_kib = _first_cpu_cache_total_kib(server)
+            cpu_cache_total_kib = (
+                server.cpu_l3_cache_total
+                or server.cpu_l2_cache_total
+                or server.cpu_l1d_cache_total
+            )
             for row in reader:
                 operation = row["operation"]
                 size_kb = int(float(row["size_kb"]))
@@ -963,18 +967,6 @@ def _l123_cache(lscpu: dict, level: int):
         return cache
     else:
         raise ValueError("Not known cache level.")
-
-
-def _first_cpu_cache_total_kib(server: "Server") -> int | None:
-    """First available total cache size in KiB (L3, then L2, then L1d)."""
-    for cache_total in (
-        server.cpu_l3_cache_total,
-        server.cpu_l2_cache_total,
-        server.cpu_l1d_cache_total,
-    ):
-        if cache_total is not None:
-            return cache_total
-    return None
 
 
 def _dropna(text: str) -> str:

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -520,7 +520,7 @@ benchmarks: List[Benchmark] = [
         measurement="memory_bandwidth",
         config_fields={
             "size_kb": "Per-thread buffer size in KiB.",
-            "scope": "RAM: working set exceeds L3 cache.",
+            "scope": "RAM: working set exceeds total CPU cache (L3, else L2, else L1d).",
         },
         unit="MB/s",
     ),
@@ -533,7 +533,7 @@ benchmarks: List[Benchmark] = [
         measurement="memory_bandwidth",
         config_fields={
             "size_kb": "Per-thread buffer size in KiB.",
-            "scope": "RAM: working set exceeds L3 cache.",
+            "scope": "RAM: working set exceeds total CPU cache (L3, else L2, else L1d).",
         },
         unit="MB/s",
     ),
@@ -546,7 +546,7 @@ benchmarks: List[Benchmark] = [
         measurement="memory_bandwidth",
         config_fields={
             "size_kb": "Per-thread buffer size in KiB.",
-            "scope": "RAM: working set exceeds L3 cache.",
+            "scope": "RAM: working set exceeds total CPU cache (L3, else L2, else L1d).",
         },
         unit="MB/s",
     ),
@@ -559,7 +559,7 @@ benchmarks: List[Benchmark] = [
         measurement="memory_latency",
         config_fields={
             "size_kb": "Per-thread buffer size in KiB.",
-            "scope": "RAM: working set exceeds L3 cache.",
+            "scope": "RAM: working set exceeds total CPU cache (L3, else L2, else L1d).",
         },
         unit="ns",
         higher_is_better=False,

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -518,7 +518,10 @@ benchmarks: List[Benchmark] = [
         description="Measures aggregate sequential read bandwidth across all threads using OpenMP parallelization.",
         framework="membench",
         measurement="memory_bandwidth",
-        config_fields={"size_kb": "Per-thread buffer size in KiB."},
+        config_fields={
+            "size_kb": "Per-thread buffer size in KiB.",
+            "scope": "RAM: working set exceeds L3 cache.",
+        },
         unit="MB/s",
     ),
     Benchmark(
@@ -528,7 +531,10 @@ benchmarks: List[Benchmark] = [
         description="Measures aggregate sequential write bandwidth across all threads using OpenMP parallelization.",
         framework="membench",
         measurement="memory_bandwidth",
-        config_fields={"size_kb": "Per-thread buffer size in KiB."},
+        config_fields={
+            "size_kb": "Per-thread buffer size in KiB.",
+            "scope": "RAM: working set exceeds L3 cache.",
+        },
         unit="MB/s",
     ),
     Benchmark(
@@ -538,7 +544,10 @@ benchmarks: List[Benchmark] = [
         description="Measures aggregate memory copy bandwidth across all threads using OpenMP parallelization.",
         framework="membench",
         measurement="memory_bandwidth",
-        config_fields={"size_kb": "Per-thread buffer size in KiB."},
+        config_fields={
+            "size_kb": "Per-thread buffer size in KiB.",
+            "scope": "RAM: working set exceeds L3 cache.",
+        },
         unit="MB/s",
     ),
     Benchmark(
@@ -548,7 +557,10 @@ benchmarks: List[Benchmark] = [
         description="Measures median memory latency using pointer chasing with randomized access to defeat hardware prefetching.",
         framework="membench",
         measurement="memory_latency",
-        config_fields={"size_kb": "Per-thread buffer size in KiB."},
+        config_fields={
+            "size_kb": "Per-thread buffer size in KiB.",
+            "scope": "RAM: working set exceeds L3 cache.",
+        },
         unit="ns",
         higher_is_better=False,
     ),

--- a/src/sc_crawler/vendors/_alicloud.py
+++ b/src/sc_crawler/vendors/_alicloud.py
@@ -634,6 +634,13 @@ locations = {
         "country_id": "TH",
         "founding_year": 2022,
     },
+    "ap-southeast-8": {
+        "city": "Johor",
+        "lat": 1.4927,
+        "lon": 103.7414,
+        "country_id": "MY",
+        "founding_year": 2025,
+    },
     # -------- United States --------
     "us-east-1": {
         "alias": ["us-east-us44-a01"],


### PR DESCRIPTION
# Overview

- Add RAM scope benchmarks for membench
- Add new AliCloud region

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [x] Branch is based on and up-to-date with `main`
- [x] PR has a clear title and/or brief description
- [x] PR builders passed
- [x] No red flags from coderabbit.ai
- [x] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [x] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RAM-scope option added to memory bandwidth and latency benchmarks for improved performance reporting
  * Alibaba Cloud ap-southeast-8 (Johor, Malaysia) region now supported

* **Documentation**
  * Changelog updated with membench scope details

* **Chores**
  * Expanded ignore rules to omit editor/config, test artifacts and generated docs/site outputs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SpareCores/sc-crawler/pull/80?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->