### PR TITLE
add vllm serving benchmarks

### DIFF
--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -296,11 +296,18 @@ _VLLM_SERVING_CONFIG_KEYS = (
     "total_vram_gb",
     "vllm_version",
     "guidellm_version",
+    "max_model_len",
+    "tuning_version",
 )
 
 
 def _vllm_serving_config(record: dict) -> dict:
     config = {key: record[key] for key in _VLLM_SERVING_CONFIG_KEYS if key in record}
+    tuning = record.get("tuning")
+    if isinstance(tuning, dict):
+        config["tuning"] = tuning
+        if "tuning_version" not in config and "tuning_version" in tuning:
+            config["tuning_version"] = tuning["tuning_version"]
     percentile = record.get("percentile")
     if percentile is not None:
         config["percentile"] = percentile

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -750,6 +750,8 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
         _log_cannot_load_benchmarks(server, framework, e, True)
 
     try:
+        from .lookup import VLLM_SERVING_MEASUREMENTS
+
         assert _server_framework_meta(server, _VLLM_TASK)["exit_code"] == 0
         with open(_server_framework_stdout_path(server, _VLLM_TASK), "r") as fp:
             for line in fp:
@@ -761,6 +763,14 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                     continue
                 measurement = record.get("measurement")
                 if not measurement:
+                    continue
+                if measurement not in VLLM_SERVING_MEASUREMENTS:
+                    logger.debug(
+                        "Skipping unknown vllm_serving measurement %r for %s/%s",
+                        measurement,
+                        server.vendor_id,
+                        server.api_reference,
+                    )
                     continue
                 benchmarks.append(
                     {

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -274,6 +274,39 @@ def _extract_line_from_file(file_path: str | PathLike, pattern: str) -> str | No
     return None
 
 
+_VLLM_TASK = "vllm"
+_VLLM_BENCHMARK_FRAMEWORK = "vllm_serving"
+_VLLM_SERVING_CONFIG_KEYS = (
+    "model",
+    "model_id",
+    "workload",
+    "prompt_tokens",
+    "output_tokens",
+    "profile",
+    "strategy",
+    "target_rate",
+    "concurrency",
+    "mode",
+    "arch",
+    "avx512",
+    "avx2_only_image",
+    "tensor_parallel",
+    "gpu_count",
+    "gpu_model",
+    "total_vram_gb",
+    "vllm_version",
+    "guidellm_version",
+)
+
+
+def _vllm_serving_config(record: dict) -> dict:
+    config = {key: record[key] for key in _VLLM_SERVING_CONFIG_KEYS if key in record}
+    percentile = record.get("percentile")
+    if percentile is not None:
+        config["percentile"] = percentile
+    return config
+
+
 def _log_cannot_load_benchmarks(server: "Server", benchmark_id, e, exc_info=False):
     logger.debug(
         "%s benchmark(s) not loaded for %s/%s: %s",
@@ -715,6 +748,33 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
                 )
     except Exception as e:
         _log_cannot_load_benchmarks(server, framework, e, True)
+
+    try:
+        assert _server_framework_meta(server, _VLLM_TASK)["exit_code"] == 0
+        with open(_server_framework_stdout_path(server, _VLLM_TASK), "r") as fp:
+            for line in fp:
+                line = line.strip()
+                if not line:
+                    continue
+                record = json.loads(line)
+                if record.get("benchmark") != _VLLM_BENCHMARK_FRAMEWORK:
+                    continue
+                measurement = record.get("measurement")
+                if not measurement:
+                    continue
+                benchmarks.append(
+                    {
+                        **_benchmark_metafields(
+                            server,
+                            framework=_VLLM_TASK,
+                            benchmark_id=f"{_VLLM_BENCHMARK_FRAMEWORK}:{measurement}",
+                        ),
+                        "config": _vllm_serving_config(record),
+                        "score": float(record["score"]),
+                    }
+                )
+    except Exception as e:
+        _log_cannot_load_benchmarks(server, _VLLM_BENCHMARK_FRAMEWORK, e, True)
 
     return benchmarks
 

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -156,6 +156,8 @@ _VLLM_SERVING_CONFIG = {
     "total_vram_gb": "Total VRAM (GiB) when mode=gpu.",
     "vllm_version": "vLLM version from the benchmark image.",
     "guidellm_version": "GuideLLM version from the benchmark image.",
+    "max_model_len": "vLLM --max-model-len for this workload/server start.",
+    "tuning_version": "Harness autoconfig revision (0=legacy static knobs).",
     "percentile": "Latency percentile (p50, p95, p99, mean); omitted for throughput rows.",
 }
 

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -160,33 +160,40 @@ _VLLM_SERVING_CONFIG = {
 }
 
 
+_VLLM_SERVING_LATENCY_MEASUREMENTS = (
+    ("ttft", "vLLM time to first token", "TTFT from GuideLLM against a vLLM server."),
+    ("tpot", "vLLM time per output token", "TPOT from GuideLLM."),
+    ("itl", "vLLM inter-token latency", "Inter-token latency from GuideLLM."),
+    ("e2el", "vLLM end-to-end latency", "End-to-end request latency from GuideLLM."),
+)
+_VLLM_SERVING_THROUGHPUT_MEASUREMENTS = (
+    (
+        "output_throughput",
+        "vLLM output token throughput",
+        "Mean output tokens per second.",
+        "tokens/sec",
+    ),
+    (
+        "total_throughput",
+        "vLLM total token throughput",
+        "Mean total tokens per second (input + output).",
+        "tokens/sec",
+    ),
+    (
+        "request_throughput",
+        "vLLM request throughput",
+        "Mean completed requests per second.",
+        "requests/sec",
+    ),
+)
+VLLM_SERVING_MEASUREMENTS = frozenset(
+    m[0] for m in _VLLM_SERVING_LATENCY_MEASUREMENTS + _VLLM_SERVING_THROUGHPUT_MEASUREMENTS
+)
+
+
 def _vllm_serving_benchmarks() -> list[Benchmark]:
-    latency = [
-        ("ttft", "vLLM time to first token", "TTFT from GuideLLM against a vLLM server."),
-        ("tpot", "vLLM time per output token", "TPOT from GuideLLM."),
-        ("itl", "vLLM inter-token latency", "Inter-token latency from GuideLLM."),
-        ("e2el", "vLLM end-to-end latency", "End-to-end request latency from GuideLLM."),
-    ]
-    throughput = [
-        (
-            "output_throughput",
-            "vLLM output token throughput",
-            "Mean output tokens per second.",
-            "tokens/sec",
-        ),
-        (
-            "total_throughput",
-            "vLLM total token throughput",
-            "Mean total tokens per second (input + output).",
-            "tokens/sec",
-        ),
-        (
-            "request_throughput",
-            "vLLM request throughput",
-            "Mean completed requests per second.",
-            "requests/sec",
-        ),
-    ]
+    latency = _VLLM_SERVING_LATENCY_MEASUREMENTS
+    throughput = _VLLM_SERVING_THROUGHPUT_MEASUREMENTS
     rows: list[Benchmark] = []
     for measurement, name, description in latency:
         rows.append(

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -136,6 +136,90 @@ def _passmark(name: str, description: str, unit: str, higher_is_better: bool = T
     )
 
 
+_VLLM_SERVING_CONFIG = {
+    "model": "Ladder short id (e.g. smol-135m, llama-8b).",
+    "model_id": "Full Hugging Face model id (e.g. meta-llama/Llama-3.1-8B-Instruct).",
+    "workload": "Synthetic workload: chat, rag, or long (long is GPU-only).",
+    "prompt_tokens": "Synthetic prompt length for the workload.",
+    "output_tokens": "Synthetic output length for the workload.",
+    "profile": "GuideLLM profile (default sweep with sync, throughput, and constant steps).",
+    "strategy": "GuideLLM scheduler strategy (synchronous, throughput, or constant).",
+    "target_rate": "Target request rate for constant-rate steps (req/s); null otherwise.",
+    "concurrency": "Mean concurrent requests during the GuideLLM step.",
+    "mode": "Serving backend: cpu or gpu.",
+    "arch": "Host architecture (amd64 or arm64).",
+    "avx512": "Whether AVX-512 was available on amd64 CPU runs.",
+    "avx2_only_image": "Whether the AVX2-only CPU image was used.",
+    "tensor_parallel": "Tensor-parallel size used for GPU serving (0 on CPU).",
+    "gpu_count": "Visible GPU count during the run (0 on CPU).",
+    "gpu_model": "GPU product name when mode=gpu.",
+    "total_vram_gb": "Total VRAM (GiB) when mode=gpu.",
+    "vllm_version": "vLLM version from the benchmark image.",
+    "guidellm_version": "GuideLLM version from the benchmark image.",
+    "percentile": "Latency percentile (p50, p95, p99, mean); omitted for throughput rows.",
+}
+
+
+def _vllm_serving_benchmarks() -> list[Benchmark]:
+    latency = [
+        ("ttft", "vLLM time to first token", "TTFT from GuideLLM against a vLLM server."),
+        ("tpot", "vLLM time per output token", "TPOT from GuideLLM."),
+        ("itl", "vLLM inter-token latency", "Inter-token latency from GuideLLM."),
+        ("e2el", "vLLM end-to-end latency", "End-to-end request latency from GuideLLM."),
+    ]
+    throughput = [
+        (
+            "output_throughput",
+            "vLLM output token throughput",
+            "Mean output tokens per second.",
+            "tokens/sec",
+        ),
+        (
+            "total_throughput",
+            "vLLM total token throughput",
+            "Mean total tokens per second (input + output).",
+            "tokens/sec",
+        ),
+        (
+            "request_throughput",
+            "vLLM request throughput",
+            "Mean completed requests per second.",
+            "requests/sec",
+        ),
+    ]
+    rows: list[Benchmark] = []
+    for measurement, name, description in latency:
+        rows.append(
+            Benchmark(
+                benchmark_id=f"vllm_serving:{measurement}",
+                name=name,
+                category="LLM serving",
+                description=description,
+                framework="vllm_serving",
+                measurement=measurement,
+                config_fields=_VLLM_SERVING_CONFIG,
+                unit="ms",
+                higher_is_better=False,
+            )
+        )
+    for measurement, name, description, unit in throughput:
+        rows.append(
+            Benchmark(
+                benchmark_id=f"vllm_serving:{measurement}",
+                name=name,
+                category="LLM serving",
+                description=description,
+                framework="vllm_serving",
+                measurement=measurement,
+                config_fields={
+                    k: v for k, v in _VLLM_SERVING_CONFIG.items() if k != "percentile"
+                },
+                unit=unit,
+            )
+        )
+    return rows
+
+
 benchmarks: List[Benchmark] = [
     Benchmark(
         benchmark_id="bogomips",
@@ -590,6 +674,7 @@ benchmarks: List[Benchmark] = [
         },
         unit="tokens/second (t/s)",
     ),
+    *_vllm_serving_benchmarks(),
 ]
 
 # dynamically add synthetic compound/augmented workloads


### PR DESCRIPTION
# Overview

<!-- brief description of what the PR does if it's not clear from the PR title -->

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added vLLM serving benchmark support for latency (TTFT, TPOT, ITL, E2EL) and throughput (output, total, request) metrics.
  * Ingests and validates vLLM benchmark output, whitelists serving configuration fields (including optional percentile), and records parsed scores and benchmark metadata for accepted measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->