### PR TITLE
Populate and correct description fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.7.x (DEVELOPMENT)
+
+Fix(es):
+
+- Populate and correct `description` fields in the `Server` table for `Vultr` and `OVH` servers.
+
 ## v0.7.0 (June 22, 2026)
 
 New vendor(s):

--- a/src/sc_crawler/vendors/_ovh.py
+++ b/src/sc_crawler/vendors/_ovh.py
@@ -685,7 +685,10 @@ def inventory_servers(vendor) -> list[dict]:
                 else None
             ),
         ]
-        description = f"{family} ({', '.join(filter(None, description_parts))})"
+        description_parts_str = ", ".join(filter(None, description_parts))
+        description = (
+            f"{family} ({description_parts_str})" if family else description_parts_str
+        )
 
         network_speed = technical.get("bandwidth", {}).get("level", None)
         network_speed_gbps = network_speed / 1000 if network_speed else None

--- a/src/sc_crawler/vendors/_vultr.py
+++ b/src/sc_crawler/vendors/_vultr.py
@@ -467,11 +467,11 @@ def inventory_servers(vendor):
         storage_type = _storage_type_from_plan(server)
         storage_size = storage_size_per_disk * server.get("disk_count", 1)
         family = _PLAN_TYPES.get(server["type"])
-        effective_vcpus = vcpus or cpu_threads
+        vcpus = vcpus or cpu_threads
         memory_amount = server["ram"]
         description = _server_description(
             family,
-            effective_vcpus,
+            vcpus,
             memory_amount,
             storage_size,
             storage_type,
@@ -489,7 +489,7 @@ def inventory_servers(vendor):
                 "display_name": server["id"],
                 "description": description,
                 "family": family,
-                "vcpus": effective_vcpus,
+                "vcpus": vcpus,
                 "hypervisor": None,
                 "cpu_allocation": cpu_allocation,
                 "cpu_cores": vcpus or cpu_count,

--- a/src/sc_crawler/vendors/_vultr.py
+++ b/src/sc_crawler/vendors/_vultr.py
@@ -273,6 +273,34 @@ def _storage_type_from_plan(plan: dict) -> StorageType:
     return _DISK_TYPES.get(plan.get("type"))
 
 
+def _server_description(
+    family: str | None,
+    vcpus: int | None,
+    memory_amount_mib: int | None,
+    storage_size: int | None,
+    storage_type: StorageType | None,
+    gpu_count: int | float | None = None,
+    gpu_model: str | None = None,
+    gpu_vram_gb: int | None = None,
+) -> str:
+    nvme_size = storage_size if storage_type == StorageType.NVME_SSD else 0
+    ssd_size = storage_size if storage_type == StorageType.SSD else 0
+    memory_size_gb = memory_amount_mib / _MIB_PER_GIB if memory_amount_mib else None
+    description_parts = [
+        f"{vcpus} vCPUs" if vcpus else None,
+        f"{memory_size_gb} GiB RAM" if memory_size_gb else None,
+        f"{nvme_size} GB NVMe" if nvme_size else None,
+        f"{ssd_size} GB SSD" if ssd_size else None,
+        (
+            f"{gpu_count}x{gpu_model} {gpu_vram_gb} GiB VRAM"
+            if gpu_count and gpu_model and gpu_vram_gb
+            else None
+        ),
+    ]
+    description_parts_str = ", ".join(filter(None, description_parts))
+    return f"{family} ({description_parts_str})" if family else description_parts_str
+
+
 @cachier(separate_files=True)
 def _get_regions():
     response = get(
@@ -438,6 +466,19 @@ def inventory_servers(vendor):
         storage_size_per_disk = server.get("disk")
         storage_type = _storage_type_from_plan(server)
         storage_size = storage_size_per_disk * server.get("disk_count", 1)
+        family = _PLAN_TYPES.get(server["type"])
+        effective_vcpus = vcpus or cpu_threads
+        memory_amount = server["ram"]
+        description = _server_description(
+            family,
+            effective_vcpus,
+            memory_amount,
+            storage_size,
+            storage_type,
+            gpu_count,
+            gpu_model,
+            gpu_vram_gb,
+        )
 
         items.append(
             {
@@ -446,9 +487,9 @@ def inventory_servers(vendor):
                 "name": server["id"],
                 "api_reference": server["id"],
                 "display_name": server["id"],
-                "description": None,
-                "family": _PLAN_TYPES.get(server["type"]),
-                "vcpus": vcpus or cpu_threads,
+                "description": description,
+                "family": family,
+                "vcpus": effective_vcpus,
                 "hypervisor": None,
                 "cpu_allocation": cpu_allocation,
                 "cpu_cores": vcpus or cpu_count,
@@ -467,7 +508,7 @@ def inventory_servers(vendor):
                 "cpu_l3_cache_total": None,
                 "cpu_flags": [],
                 "cpus": [],
-                "memory_amount": server["ram"],
+                "memory_amount": memory_amount,
                 "memory_generation": None,
                 "memory_speed": None,
                 "memory_ecc": None,


### PR DESCRIPTION
# Overview

Populate and correct `description` fields in the `Server` table for `Vultr` and `OVH` servers.

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [x] Branch is based on and up-to-date with `main`
- [x] PR has a clear title and/or brief description
- [x] PR builders passed
- [x] No red flags from coderabbit.ai
- [x] Pinged code owners for human review after all other major items in this list are completed
- [x] Human approval

Versioning, changelog, and documentation:

- [x] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [x] `sc-crawler pull` was tested on all vendors and records
- [x] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [x] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server descriptions are now correctly populated for Vultr and OVH servers with improved formatting displaying CPU, memory, storage, and GPU information in a more readable format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->