### PR TITLE
Fix Azure errors and fix Pydantic and SQLAlchemy warnings

### DIFF
--- a/src/sc_crawler/description_ingestor.py
+++ b/src/sc_crawler/description_ingestor.py
@@ -75,7 +75,7 @@ def ingest_server_description(server: "Server") -> dict | None:
     try:
         output = _load_server_description_output(server)
         fields = ServerDescriptionFields.model_validate(output)
-        return {**_server_ids(server), **fields.model_dump()}
+        return {**_server_ids(server), **fields.model_dump(mode="json")}
     except Exception as e:
         _log_cannot_load_description(server, e)
         return None

--- a/src/sc_crawler/table_bases.py
+++ b/src/sc_crawler/table_bases.py
@@ -890,6 +890,12 @@ class BenchmarkFields(HasDescription, HasName, HasCategory, HasBenchmarkIdPK):
     )
 
 
+def _coerce_categories(value) -> list[Category]:
+    if not value:
+        return []
+    return [Category(item) if isinstance(item, str) else item for item in value]
+
+
 class ServerDescriptionFields(ScModel):
     page: List[str] = Field(
         sa_type=JSON,
@@ -979,14 +985,19 @@ class ServerDescriptionFields(ScModel):
             raise ValueError(f"bullet_points must have 4-6 items, got {len(v)}")
         return v
 
-    @field_validator("categories")
+    @field_validator("categories", mode="before")
     @classmethod
-    def validate_categories(cls, v: list[Category]) -> list[Category]:
-        if len(v) < 1 or len(v) > 3:
-            raise ValueError(f"categories must have 1-3 items, got {len(v)}")
-        if len(v) != len(set(v)):
+    def validate_categories(cls, v):
+        categories = _coerce_categories(v)
+        if len(categories) < 1 or len(categories) > 3:
+            raise ValueError(f"categories must have 1-3 items, got {len(categories)}")
+        if len(categories) != len(set(categories)):
             raise ValueError("categories must not contain duplicates")
-        return v
+        return categories
+
+    @reconstructor
+    def _reconstruct_categories(self):
+        self.categories = _coerce_categories(self.categories)
 
 
 class ServerDescriptionBase(

--- a/src/sc_crawler/table_fields.py
+++ b/src/sc_crawler/table_fields.py
@@ -25,6 +25,7 @@ class HashableJSON(TypeDecorator):
     """Alternative JSON SQLAlchemy column representation, which can be hashed."""
 
     impl = JSON
+    cache_ok = True
 
     def process_result_value(self, value: str, dialect: Any) -> Any:
         if value is None:

--- a/src/sc_crawler/vendors/_azure.py
+++ b/src/sc_crawler/vendors/_azure.py
@@ -1168,12 +1168,15 @@ def inventory_zones(vendor):
     """
     items = []
     resources = _resources("Microsoft.Compute")
-    locations = [
-        i
-        for i in resources
-        if i.get("resource_type") == "virtualMachines"
-        or i.get("resourceType") == "virtualMachines"
-    ][0]
+    locations = next(
+        (
+            i
+            for i in resources
+            if i.get("resource_type") == "virtualMachines"
+            or i.get("resourceType") == "virtualMachines"
+        ),
+        {},
+    )
     zone_mappings = locations.get("zone_mappings", locations.get("zoneMappings", []))
     locations = {item["location"]: item["zones"] for item in zone_mappings}
     for region in vendor.regions:

--- a/src/sc_crawler/vendors/_azure.py
+++ b/src/sc_crawler/vendors/_azure.py
@@ -1102,7 +1102,11 @@ def inventory_regions(vendor):
         with sentry_capture_or_raise(vendor=vendor):
             # TODO drop this once the metadata field doesn't show up randomly anymore
             # as the non-metadata responses do not seem to have these logical regions anymore
-            if region.get("metadata", {}).get("regionType", "Physical") != "Physical":
+            metadata = region.get("metadata", {})
+            region_type = metadata.get("regionType") or metadata.get(
+                "region_type", "Physical"
+            )
+            if region_type != "Physical":
                 continue
             # no idea what are these
             if region["name"].endswith("stg"):
@@ -1164,8 +1168,14 @@ def inventory_zones(vendor):
     """
     items = []
     resources = _resources("Microsoft.Compute")
-    locations = [i for i in resources if i["resourceType"] == "virtualMachines"][0]
-    locations = {item["location"]: item["zones"] for item in locations["zoneMappings"]}
+    locations = [
+        i
+        for i in resources
+        if i.get("resource_type") == "virtualMachines"
+        or i.get("resourceType") == "virtualMachines"
+    ][0]
+    zone_mappings = locations.get("zone_mappings", locations.get("zoneMappings", []))
+    locations = {item["location"]: item["zones"] for item in zone_mappings}
     for region in vendor.regions:
         # default to zone with 0 ID if there are no real availability zones
         region_zones = locations.get(region.name, ["0"])

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -1,7 +1,10 @@
+import warnings
+
 import pytest
 
-from sc_crawler.table_bases import ServerBase, StoragePriceBase
+from sc_crawler.table_bases import ServerBase, ServerDescriptionFields, StoragePriceBase
 from sc_crawler.table_fields import (
+    Category,
     Cpu,
     Disk,
     Gpu,
@@ -285,6 +288,48 @@ def test_storage_price_tiered_validator_with_empty_list():
 
     # Verify that empty list is preserved
     assert storage_price.price_tiered == []
+
+
+def test_server_description_categories_validator_with_strings():
+    """Test that categories field validator converts strings to Category instances."""
+    description = ServerDescriptionFields(
+        page=["word " * 50],
+        description="word " * 100,
+        og_description="x" * 200,
+        meta_description="x" * 150,
+        tagline="word " * 20,
+        bullet_points=["a", "b", "c", "d"],
+        categories=["General Purpose", "Compute Optimized"],
+    )
+
+    assert len(description.categories) == 2
+    assert all(isinstance(category, Category) for category in description.categories)
+    assert description.categories[0] == Category.GENERAL_PURPOSE
+    assert description.categories[1] == Category.COMPUTE_OPTIMIZED
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        dumped = description.model_dump()
+        assert dumped["categories"] == [
+            Category.GENERAL_PURPOSE,
+            Category.COMPUTE_OPTIMIZED,
+        ]
+        assert not caught
+
+    reconstructed = ServerDescriptionFields.model_construct(
+        page=description.page,
+        description=description.description,
+        og_description=description.og_description,
+        meta_description=description.meta_description,
+        tagline=description.tagline,
+        bullet_points=description.bullet_points,
+        categories=["General Purpose", "Compute Optimized"],
+    )
+    reconstructed._reconstruct_categories()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        reconstructed.model_dump()
+        assert not caught
 
 
 def test_storage_price_tiered_validator_with_mixed_bounds():


### PR DESCRIPTION
# Overview

- Fix key errors in _azure.py 
- Fix Pydantic serializer and SQLAlchemy warnings
- Update test_schemas.py

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of server categories so text values are accepted and normalized consistently, while still enforcing valid count and uniqueness rules.
  * Made server description data serialization more consistent when returned to users.
  * Updated Azure region and zone processing to handle alternate field names more reliably.
* **Performance**
  * Enabled safer caching for JSON value handling to support more efficient query processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->