### PR TITLE
Dev 894 create database benchmark score table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,7 @@
 
 New feature(s):
 
-- Add `database_benchmark_score` table (and SCD mirror) for managed-database
-  benchmark results, mirroring `benchmark_score` with PK
-  `(vendor_id, database_id, benchmark_id, config)` and a composite FK to
-  `database`. The existing `benchmark_score` table is unchanged.
+- Add `database_benchmark_score` table for database benchmark results, mirroring `benchmark_score`.
 
 ## v0.8.3 (July 21, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,13 @@
-## v0.8.3 (July 15, 2026)
+## v0.8.4 (DEVELOPMENT)
+
+New feature(s):
+
+- Add `database_benchmark_score` table (and SCD mirror) for managed-database
+  benchmark results, mirroring `benchmark_score` with PK
+  `(vendor_id, database_id, benchmark_id, config)` and a composite FK to
+  `database`. The existing `benchmark_score` table is unchanged.
+
+## v0.8.3 (July 21, 2026)
 
 New feature(s):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.8.x (DEVELOPMENT)
+## v0.8.4 (July 28, 2026)
 
 New feature(s):
 

--- a/src/sc_crawler/__init__.py
+++ b/src/sc_crawler/__init__.py
@@ -1,4 +1,4 @@
 """Spare Cores crawler: collect and standardize cloud server offerings data."""
 
-__version__ = "0.8.3"
+__version__ = "0.8.4"
 __version_info__ = tuple(int(x) for x in __version__.split(".")[:3])

--- a/src/sc_crawler/alembic/versions/d5e6f7a8b9c0_v0_8_4_add_database_benchmark_score.py
+++ b/src/sc_crawler/alembic/versions/d5e6f7a8b9c0_v0_8_4_add_database_benchmark_score.py
@@ -108,12 +108,6 @@ def upgrade() -> None:
             comment="The version of the benchmark tool used.",
         ),
         sa.Column(
-            "kernel_version",
-            sqlmodel.sql.sqltypes.AutoString(),
-            nullable=True,
-            comment="The kernel version when the benchmark was run.",
-        ),
-        sa.Column(
             "score",
             sa.Float(),
             nullable=False,

--- a/src/sc_crawler/alembic/versions/d5e6f7a8b9c0_v0_8_4_add_database_benchmark_score.py
+++ b/src/sc_crawler/alembic/versions/d5e6f7a8b9c0_v0_8_4_add_database_benchmark_score.py
@@ -1,0 +1,159 @@
+"""v0.8.4 add database_benchmark_score table
+
+Revision ID: d5e6f7a8b9c0
+Revises: c4d5e6f7a8b9
+Create Date: 2026-07-20 15:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+revision: str = "d5e6f7a8b9c0"
+down_revision: Union[str, None] = "c4d5e6f7a8b9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def is_scd_migration() -> bool:
+    return bool(op.get_context().config.attributes.get("scd"))
+
+
+def scdize_suffix(table_name: str) -> str:
+    if is_scd_migration():
+        return table_name + "_scd"
+    return table_name
+
+
+def _enum(name: str, values: tuple[str, ...]):
+    is_postgresql = op.get_context().dialect.name == "postgresql"
+    if is_postgresql:
+        return sa.dialects.postgresql.ENUM(*values, name=name, create_type=False)
+    return sa.Enum(*values, name=name)
+
+
+def upgrade() -> None:
+    is_postgresql = op.get_context().dialect.name == "postgresql"
+    json_type = sa.dialects.postgresql.JSONB if is_postgresql else sa.JSON
+    is_scd = is_scd_migration()
+
+    vendor_table = scdize_suffix("vendor")
+    database_table = scdize_suffix("database")
+    benchmark_table = scdize_suffix("benchmark")
+    table_name = scdize_suffix("database_benchmark_score")
+
+    primary_keys = (
+        ("vendor_id", "database_id", "benchmark_id", "config", "observed_at")
+        if is_scd
+        else ("vendor_id", "database_id", "benchmark_id", "config")
+    )
+    foreign_keys = (
+        (
+            sa.ForeignKeyConstraint(
+                ["benchmark_id"],
+                [f"{benchmark_table}.benchmark_id"],
+                name=op.f(f"fk_{table_name}_benchmark_id_{benchmark_table}"),
+            ),
+            sa.ForeignKeyConstraint(
+                ["vendor_id", "database_id"],
+                [f"{database_table}.vendor_id", f"{database_table}.database_id"],
+                name=op.f(f"fk_{table_name}_vendor_id_{database_table}"),
+            ),
+            sa.ForeignKeyConstraint(
+                ["vendor_id"],
+                [f"{vendor_table}.vendor_id"],
+                name=op.f(f"fk_{table_name}_vendor_id_{vendor_table}"),
+            ),
+        )
+        if not is_scd
+        else ()
+    )
+
+    op.create_table(
+        table_name,
+        sa.Column(
+            "vendor_id",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            comment="Reference to the Vendor.",
+        ),
+        sa.Column(
+            "database_id",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            comment="Reference to the Database.",
+        ),
+        sa.Column(
+            "benchmark_id",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            comment="Reference to the Benchmark.",
+        ),
+        sa.Column(
+            "config",
+            json_type,
+            nullable=False,
+            comment=(
+                'Dictionary of config parameters of the specific benchmark, '
+                'e.g. {"bandwidth": 4096}'
+            ),
+        ),
+        sa.Column(
+            "framework_version",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            comment="The version of the benchmark tool used.",
+        ),
+        sa.Column(
+            "kernel_version",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            comment="The kernel version when the benchmark was run.",
+        ),
+        sa.Column(
+            "score",
+            sa.Float(),
+            nullable=False,
+            comment="The resulting score of the benchmark.",
+        ),
+        sa.Column(
+            "score_breakdown",
+            json_type,
+            nullable=True,
+            comment=(
+                "Structured derivation of composite scores (e.g. workload profiles): "
+                "per-component raw values, references, normalized values, weights, and "
+                "coverage. Null for simple benchmark scores."
+            ),
+        ),
+        sa.Column(
+            "note",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            comment="Optional note, comment or context on the benchmark score.",
+        ),
+        sa.Column(
+            "status",
+            _enum("status", ("ACTIVE", "INACTIVE")),
+            nullable=False,
+            comment="Status of the resource (active or inactive).",
+        ),
+        sa.Column(
+            "observed_at",
+            sa.DateTime(),
+            nullable=False,
+            comment="Timestamp of the last observation.",
+        ),
+        *foreign_keys,
+        sa.PrimaryKeyConstraint(*primary_keys, name=op.f(f"pk_{table_name}")),
+        comment="Results of running Benchmark scenarios on managed Databases."
+        if not is_scd
+        else "SCD version of .tables.DatabaseBenchmarkScore.",
+    )
+
+
+def downgrade() -> None:
+    op.drop_table(scdize_suffix("database_benchmark_score"))

--- a/src/sc_crawler/alembic/versions/d5e6f7a8b9c0_v0_8_4_add_database_benchmark_score.py
+++ b/src/sc_crawler/alembic/versions/d5e6f7a8b9c0_v0_8_4_add_database_benchmark_score.py
@@ -97,7 +97,7 @@ def upgrade() -> None:
             json_type,
             nullable=False,
             comment=(
-                'Dictionary of config parameters of the specific benchmark, '
+                "Dictionary of config parameters of the specific benchmark, "
                 'e.g. {"bandwidth": 4096}'
             ),
         ),

--- a/src/sc_crawler/table_bases.py
+++ b/src/sc_crawler/table_bases.py
@@ -1340,10 +1340,6 @@ class DatabaseBenchmarkScoreFields(HasBenchmarkPKFK, HasDatabasePK, HasVendorPKF
         default=None,
         description="The version of the benchmark tool used.",
     )
-    kernel_version: Optional[str] = Field(
-        default=None,
-        description="The kernel version when the benchmark was run.",
-    )
     score: float = Field(
         description="The resulting score of the benchmark.",
     )

--- a/src/sc_crawler/table_bases.py
+++ b/src/sc_crawler/table_bases.py
@@ -1313,3 +1313,74 @@ class BenchmarkScoreFields(HasBenchmarkPKFK, HasServerPK, HasVendorPKFK):
 
 class BenchmarkScoreBase(MetaColumns, BenchmarkScoreFields):
     pass
+
+
+class DatabaseBenchmarkScoreFields(HasBenchmarkPKFK, HasDatabasePK, HasVendorPKFK):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    @model_validator(mode="before")
+    def update_config_to_hashable(cls, values):
+        """We need a hashable column for the primary key.
+
+        Note that we also sort the keys, so that the resulting JSON
+        can be compared as text as well (as some database engines do).
+        """
+        values["config"] = HashableDict(sorted(values.get("config", {}).items()))
+        return values
+
+    # use HashableDict as it's a primary key that needs to be hashable, but
+    # fall back to dict to avoid PydanticInvalidForJsonSchema
+    config: HashableDict | dict = Field(
+        default={},
+        sa_type=HashableJSON,
+        primary_key=True,
+        description='Dictionary of config parameters of the specific benchmark, e.g. {"bandwidth": 4096}',
+    )
+    framework_version: Optional[str] = Field(
+        default=None,
+        description="The version of the benchmark tool used.",
+    )
+    kernel_version: Optional[str] = Field(
+        default=None,
+        description="The kernel version when the benchmark was run.",
+    )
+    score: float = Field(
+        description="The resulting score of the benchmark.",
+    )
+    score_breakdown: Optional[WorkloadScoreBreakdown] = Field(
+        default=None,
+        sa_type=JSON,
+        description=(
+            "Structured derivation of composite scores (e.g. workload profiles): "
+            "per-component raw values, references, normalized values, weights, and "
+            "coverage. Null for simple benchmark scores."
+        ),
+    )
+    note: Optional[str] = Field(
+        default=None,
+        description="Optional note, comment or context on the benchmark score.",
+    )
+
+    @field_serializer("score_breakdown")
+    def _serialize_score_breakdown(self, value: Optional[WorkloadScoreBreakdown]):
+        if value is None or isinstance(value, dict):
+            return value
+        if hasattr(value, "__json__"):
+            return value.__json__()
+        return value
+
+    @field_validator("score_breakdown", mode="before")
+    @classmethod
+    def _deserialize_score_breakdown(cls, value):
+        """Coerce a dict to WorkloadScoreBreakdown on construction."""
+        return WorkloadScoreBreakdown(**value) if isinstance(value, dict) else value
+
+    @reconstructor
+    def _reconstruct_score_breakdown(self):
+        """Re-coerce score_breakdown from the dict returned by a DB load."""
+        if isinstance(self.score_breakdown, dict):
+            self.score_breakdown = WorkloadScoreBreakdown(**self.score_breakdown)
+
+
+class DatabaseBenchmarkScoreBase(MetaColumns, DatabaseBenchmarkScoreFields):
+    pass

--- a/src/sc_crawler/tables.py
+++ b/src/sc_crawler/tables.py
@@ -26,6 +26,7 @@ from .table_bases import (
     ComplianceFrameworkBase,
     CountryBase,
     DatabaseBase,
+    DatabaseBenchmarkScoreBase,
     DatabasePriceBase,
     DatabaseStorageBase,
     DatabaseStoragePriceBase,
@@ -123,6 +124,9 @@ class Vendor(VendorBase, table=True):
         back_populates="vendor", sa_relationship_kwargs={"viewonly": True}
     )
     benchmark_scores: List["BenchmarkScore"] = Relationship(
+        back_populates="vendor", sa_relationship_kwargs={"viewonly": True}
+    )
+    database_benchmark_scores: List["DatabaseBenchmarkScore"] = Relationship(
         back_populates="vendor", sa_relationship_kwargs={"viewonly": True}
     )
 
@@ -615,6 +619,9 @@ class Database(DatabaseBase, table=True):
     prices: List["DatabasePrice"] = Relationship(
         back_populates="database", sa_relationship_kwargs={"viewonly": True}
     )
+    database_benchmark_scores: List["DatabaseBenchmarkScore"] = Relationship(
+        back_populates="database", sa_relationship_kwargs={"viewonly": True}
+    )
 
 
 class DatabasePrice(DatabasePriceBase, table=True):
@@ -751,6 +758,9 @@ class Benchmark(BenchmarkBase, table=True):
     benchmark_scores: List["BenchmarkScore"] = Relationship(
         back_populates="benchmark", sa_relationship_kwargs={"viewonly": True}
     )
+    database_benchmark_scores: List["DatabaseBenchmarkScore"] = Relationship(
+        back_populates="benchmark", sa_relationship_kwargs={"viewonly": True}
+    )
 
 
 class BenchmarkScore(BenchmarkScoreBase, table=True):
@@ -776,6 +786,29 @@ class BenchmarkScore(BenchmarkScoreBase, table=True):
     benchmark: Benchmark = Relationship(back_populates="benchmark_scores")
 
 
+class DatabaseBenchmarkScore(DatabaseBenchmarkScoreBase, table=True):
+    """Results of running Benchmark scenarios on managed Databases."""
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["vendor_id", "database_id"],
+            ["database.vendor_id", "database.database_id"],
+        ),
+    )
+    vendor: Vendor = Relationship(back_populates="database_benchmark_scores")
+    database: Database = Relationship(
+        back_populates="database_benchmark_scores",
+        sa_relationship_kwargs={
+            "primaryjoin": (
+                "and_(Database.database_id == foreign(DatabaseBenchmarkScore.database_id), "
+                "Database.vendor_id == foreign(DatabaseBenchmarkScore.vendor_id))"
+            ),
+            "overlaps": "vendor",
+        },
+    )
+    benchmark: Benchmark = Relationship(back_populates="database_benchmark_scores")
+
+
 Country.model_rebuild()
 ComplianceFramework.model_rebuild()
 Vendor.model_rebuild()
@@ -786,6 +819,7 @@ Storage.model_rebuild()
 Server.model_rebuild()
 Database.model_rebuild()
 DatabaseStorage.model_rebuild()
+Benchmark.model_rebuild()
 
 
 def is_table(table):

--- a/src/sc_crawler/tables_scd.py
+++ b/src/sc_crawler/tables_scd.py
@@ -11,6 +11,7 @@ from .table_bases import (
     ComplianceFrameworkBase,
     CountryBase,
     DatabaseBase,
+    DatabaseBenchmarkScoreBase,
     DatabasePriceBase,
     DatabaseStorageBase,
     DatabaseStoragePriceBase,
@@ -214,6 +215,19 @@ class BenchmarkScd(Scd, BenchmarkBase, table=True):
 
 class BenchmarkScoreScd(Scd, BenchmarkScoreBase, table=True):
     """SCD version of .tables.BenchmarkScore."""
+
+    benchmark_id: str = Field(
+        primary_key=True,
+        description="Reference to the Benchmark.",
+    )
+    vendor_id: str = Field(
+        primary_key=True,
+        description="Reference to the Vendor.",
+    )
+
+
+class DatabaseBenchmarkScoreScd(Scd, DatabaseBenchmarkScoreBase, table=True):
+    """SCD version of .tables.DatabaseBenchmarkScore."""
 
     benchmark_id: str = Field(
         primary_key=True,

--- a/src/sc_crawler/vendors/_aws.py
+++ b/src/sc_crawler/vendors/_aws.py
@@ -1725,6 +1725,8 @@ def inventory_database_storage_prices(vendor):
             region_id = attrs["regionCode"]
             if region_id not in region_ids:
                 continue
+            if attrs.get("deploymentOption") != "Single-AZ":
+                continue
             storage_id = next(
                 (
                     k

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -1,5 +1,10 @@
 from sc_crawler.insert import _dedupe_items, _primary_key_tuple
-from sc_crawler.table_bases import BenchmarkScoreBase, DatabaseBase, DatabasePriceBase
+from sc_crawler.table_bases import (
+    BenchmarkScoreBase,
+    DatabaseBase,
+    DatabaseBenchmarkScoreBase,
+    DatabasePriceBase,
+)
 from sc_crawler.table_fields import Allocation, DatabaseEngine, PriceUnit, Status
 
 
@@ -83,3 +88,19 @@ def test_database_base_round_trip():
     )
     assert item.engine_versions == ["15", "16"]
     assert item.storage_size is None
+
+
+def test_database_benchmark_score_base_round_trip():
+    item = DatabaseBenchmarkScoreBase.model_validate(
+        {
+            "vendor_id": "gcp",
+            "database_id": "db-n1-standard-4",
+            "benchmark_id": "pgbench_tps",
+            "config": {"scale": 100, "clients": 4},
+            "score": 1234.5,
+            "status": Status.ACTIVE,
+        }
+    )
+    assert item.database_id == "db-n1-standard-4"
+    assert item.config == {"clients": 4, "scale": 100}
+    assert item.score == 1234.5

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -14,8 +14,10 @@ from sc_crawler.table_fields import (
     StorageType,
 )
 from sc_crawler.tables import (
+    BenchmarkScore,
     Country,
     Database,
+    DatabaseBenchmarkScore,
     DatabasePrice,
     DatabaseStoragePrice,
     StoragePrice,
@@ -33,6 +35,23 @@ def test_scmodels_have_base():
         assert schema.__name__.endswith("Base")
         assert hasattr(model, "__table__")
         assert not hasattr(schema, "__table__")
+
+
+def test_database_benchmark_score_primary_keys_mirror_benchmark_score():
+    assert BenchmarkScore.get_columns()["primary_keys"] == [
+        "vendor_id",
+        "server_id",
+        "benchmark_id",
+        "config",
+    ]
+    assert DatabaseBenchmarkScore.get_columns()["primary_keys"] == [
+        "vendor_id",
+        "database_id",
+        "benchmark_id",
+        "config",
+    ]
+    assert "server_id" not in DatabaseBenchmarkScore.get_columns()["all"]
+    assert DatabaseBenchmarkScore.get_table_name() == "database_benchmark_score"
 
 
 def test_database_price_primary_keys_match_storage_price_shape():


### PR DESCRIPTION
# Overview

Add `database_benchmark_score` table for database benchmark results, mirroring `benchmark_score`.

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for storing and accessing benchmark results scoped to individual databases.
  - Database benchmark scores include configurations, scores, score breakdowns, framework versions, status, notes, and observation timestamps.
  - Added historical tracking for database benchmark scores.
  - Connected database benchmark results with vendors, databases, and benchmarks.

- **Release**
  - Updated the package version to 0.8.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->