### PR TITLE
Filter AWS inventory database storage prices to include only Single-AZ deployments

### DIFF
--- a/src/sc_crawler/vendors/_aws.py
+++ b/src/sc_crawler/vendors/_aws.py
@@ -1725,6 +1725,8 @@ def inventory_database_storage_prices(vendor):
             region_id = attrs["regionCode"]
             if region_id not in region_ids:
                 continue
+            if attrs.get("deploymentOption") != "Single-AZ":
+                continue
             storage_id = next(
                 (
                     k

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -81,6 +81,7 @@ def _aws_rds_storage_product(
     *,
     volume_type: str,
     region: str = "us-east-1",
+    deployment: str = "Single-AZ",
     price: str = "0.115",
 ) -> dict:
     return {
@@ -89,6 +90,7 @@ def _aws_rds_storage_product(
             "attributes": {
                 "volumeType": volume_type,
                 "regionCode": region,
+                "deploymentOption": deployment,
             },
         },
         "terms": _aws_ondemand_terms(price),
@@ -744,6 +746,12 @@ def test_aws_inventory_database_storage_prices_skip_missing_catalog():
         _aws_rds_storage_product(volume_type="General Purpose-GP3", price="0.08"),
         _aws_rds_storage_product(volume_type="Magnetic", price="0.10"),
         _aws_rds_storage_product(volume_type="General Purpose", region="eu-west-1"),
+        _aws_rds_storage_product(
+            volume_type="General Purpose-GP3",
+            region="us-east-1",
+            deployment="Multi-AZ",
+            price="0.16",
+        ),
         _aws_rds_storage_product(
             volume_type="General Purpose-GP3", region="ap-south-1", price="0.09"
         ),

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -762,8 +762,9 @@ def test_aws_inventory_database_storage_prices_skip_missing_catalog():
         return_value=products,
     ):
         prices = aws_database_storage_prices(vendor)
-    assert {(p["database_storage_id"], p["region_id"]) for p in prices} == {
-        ("gp3", "us-east-1"),
-        ("gp2", "eu-west-1"),
+    assert len(prices) == 2
+    assert {(p["database_storage_id"], p["region_id"], p["price"]) for p in prices} == {
+        ("gp3", "us-east-1", 0.08),
+        ("gp2", "eu-west-1", 0.115),
     }
     assert prices[0]["unit"] == PriceUnit.GB_MONTH


### PR DESCRIPTION
# Overview

HOTFIX: Filter AWS inventory database storage prices to include only Single-AZ deployments

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database storage pricing accuracy by excluding pricing entries for unsupported Multi-AZ deployments.
  * Ensured only eligible Single-AZ database storage prices are included in inventory results.
* **Tests**
  * Added coverage to verify Multi-AZ pricing entries are skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->