### PR TITLE
Separate logarithm from normalization in workload profile scoring

### DIFF
--- a/src/sc_crawler/workload_profile_scores.py
+++ b/src/sc_crawler/workload_profile_scores.py
@@ -228,7 +228,7 @@ def _normalise(raw: float, fleet_median: float, higher_is_better: bool) -> float
     if raw <= 0 or fleet_median <= 0:
         return None
     ratio = raw / fleet_median if higher_is_better else fleet_median / raw
-    return log2(ratio)
+    return ratio
 
 
 def _component_note_for_invalid(raw: float | None) -> str | None:
@@ -284,9 +284,8 @@ def _compute_workload_score_rows(
                         component_note = _component_note_for_invalid(raw)
 
                 if norm is not None:
-                    log_weighted_sum += norm * entry.weight
+                    log_weighted_sum += log2(norm) * entry.weight
                     total_weight += entry.weight
-                    normalized = 2**norm
                     breakdown_components.append(
                         ScoreComponent(
                             label=entry.label,
@@ -294,7 +293,7 @@ def _compute_workload_score_rows(
                             weight_share=0.0,  # filled after total_weight known
                             raw=_round_measurement(raw),
                             reference=_round_measurement(fleet_median),
-                            normalized=_round_sigfigs(normalized, sig=3),
+                            normalized=_round_sigfigs(norm, sig=3),
                             higher_is_better=higher,
                             note=None,
                         )
@@ -320,8 +319,7 @@ def _compute_workload_score_rows(
 
                 if policy == BenchmarkComponentMissingPolicy.PENALIZE:
                     penalty = entry.effective_penalty()
-                    norm = log2(penalty)
-                    log_weighted_sum += norm * entry.weight
+                    log_weighted_sum += log2(penalty) * entry.weight
                     total_weight += entry.weight
                     breakdown_components.append(
                         ScoreComponent(

--- a/src/sc_crawler/workload_profile_scores.py
+++ b/src/sc_crawler/workload_profile_scores.py
@@ -224,7 +224,7 @@ def _load_scores(
 
 
 def _normalise(raw: float, fleet_median: float, higher_is_better: bool) -> float | None:
-    """Normalise *raw* to a log2 ratio to the per-benchmark median, or None if invalid."""
+    """Normalise *raw* to a ratio to the per-benchmark median, or None if invalid."""
     if raw <= 0 or fleet_median <= 0:
         return None
     ratio = raw / fleet_median if higher_is_better else fleet_median / raw

--- a/tests/test_workload_profile_scores.py
+++ b/tests/test_workload_profile_scores.py
@@ -36,8 +36,8 @@ def _reconstruct_score_from_breakdown(breakdown: WorkloadScoreBreakdown) -> floa
             )
             assert norm is not None
         else:
-            norm = math.log2(component.normalized)
-        log_weighted_sum += norm * component.weight
+            norm = component.normalized
+        log_weighted_sum += math.log2(norm) * component.weight
     return 2 ** (log_weighted_sum / breakdown.coverage)
 
 
@@ -76,13 +76,13 @@ def test_round_sigfigs_compound_score():
 
 
 def test_normalise_higher_is_better():
-    assert _normalise(200.0, 100.0, True) == pytest.approx(1.0)
-    assert _normalise(50.0, 100.0, True) == pytest.approx(-1.0)
+    assert _normalise(200.0, 100.0, True) == pytest.approx(2.0)
+    assert _normalise(50.0, 100.0, True) == pytest.approx(0.5)
 
 
 def test_normalise_lower_is_better():
-    assert _normalise(50.0, 100.0, False) == pytest.approx(1.0)
-    assert _normalise(200.0, 100.0, False) == pytest.approx(-1.0)
+    assert _normalise(50.0, 100.0, False) == pytest.approx(2.0)
+    assert _normalise(200.0, 100.0, False) == pytest.approx(0.5)
 
 
 def test_normalise_invalid_values():


### PR DESCRIPTION
# Overview

This is a tiny refactor of the workload profile scoring to move the logarithm from the normalization function into the geometric mean computation (as discussed in #92). 

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload score normalization to preserve accurate linear ratios.
  * Corrected score calculations for both higher-is-better and lower-is-better metrics.
  * Updated handling of missing values to ensure penalty calculations remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->