### PR TITLE
Fix GCP cpu_architecture for Axion C4A/N4A (v0.8.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,10 @@
-## v0.8.5 (August 1, 2026)
+## v0.8.x (development)
 
 Fix(es):
 
 - GCP: `cpu_architecture` was hardcoded to only recognize `t2a` as `ARM64`, defaulting
   every other series (including the Arm-based Axion `c4a`/`n4a`) to `X86_64`. Now reads
-  the real `MachineType.architecture` API field instead (confirmed live: correctly
-  reports `ARM64` for `t2a`/`c4a`/`n4a` today, and will auto-detect any future ARM
-  series with no code change; older series that don't populate the field default to
-  `X86_64`, which is accurate for all of them).
+  the real `MachineType.architecture` API field instead.
 
 ## v0.8.4 (July 28, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## v0.8.5 (August 1, 2026)
+
+Fix(es):
+
+- GCP: `cpu_architecture` was hardcoded to only recognize `t2a` as `ARM64`, defaulting
+  every other series (including the Arm-based Axion `c4a`/`n4a`) to `X86_64`. Now reads
+  the real `MachineType.architecture` API field instead (confirmed live: correctly
+  reports `ARM64` for `t2a`/`c4a`/`n4a` today, and will auto-detect any future ARM
+  series with no code change; older series that don't populate the field default to
+  `X86_64`, which is accurate for all of them).
+
 ## v0.8.4 (July 28, 2026)
 
 New feature(s):

--- a/src/sc_crawler/__init__.py
+++ b/src/sc_crawler/__init__.py
@@ -1,4 +1,4 @@
 """Spare Cores crawler: collect and standardize cloud server offerings data."""
 
-__version__ = "0.8.5"
+__version__ = "0.8.4"
 __version_info__ = tuple(int(x) for x in __version__.split(".")[:3])

--- a/src/sc_crawler/__init__.py
+++ b/src/sc_crawler/__init__.py
@@ -1,4 +1,4 @@
 """Spare Cores crawler: collect and standardize cloud server offerings data."""
 
-__version__ = "0.8.4"
+__version__ = "0.8.5"
 __version_info__ = tuple(int(x) for x in __version__.split(".")[:3])

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -306,9 +306,15 @@ def _search_servers(zone_name: str) -> List[dict]:
                 ),
                 "cpu_cores": None,
                 "cpu_speed": None,
+                # MachineType.architecture is a real, stable API field (confirmed
+                # live for all current series, e.g. t2a/c4a/n4a -> ARM64), so we
+                # read it directly instead of hardcoding known ARM series names.
+                # Older machine types don't populate it at all (empty string),
+                # defaulting those to X86_64 - accurate for everything on GCE today.
+                # https://cloud.google.com/compute/docs/reference/rest/v1/machineTypes
                 "cpu_architecture": (
                     CpuArchitecture.ARM64
-                    if server.name.startswith("t2a")
+                    if str(server.architecture or "").upper() == "ARM64"
                     else CpuArchitecture.X86_64
                 ),
                 "cpu_manufacturer": None,

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -70,6 +70,9 @@ def _zones() -> List[compute_v1.types.compute.Zone]:
 
 @cachier(separate_files=True)
 def _servers(zone: str) -> List[compute_v1.types.compute.MachineType]:
+    """List all machine types available in a Zone.
+
+    Reference: <https://cloud.google.com/compute/docs/reference/rest/v1/machineTypes>."""
     return _paginate_list(compute_v1.services.machine_types.MachineTypesClient(), zone)
 
 
@@ -306,12 +309,8 @@ def _search_servers(zone_name: str) -> List[dict]:
                 ),
                 "cpu_cores": None,
                 "cpu_speed": None,
-                # MachineType.architecture is a real, stable API field (confirmed
-                # live for all current series, e.g. t2a/c4a/n4a -> ARM64), so we
-                # read it directly instead of hardcoding known ARM series names.
-                # Older machine types don't populate it at all (empty string),
-                # defaulting those to X86_64 - accurate for everything on GCE today.
-                # https://cloud.google.com/compute/docs/reference/rest/v1/machineTypes
+                # older machine types don't populate MachineType.architecture,
+                # but it's confirmed to be present for t2a/c4a/n4a (ARM64)
                 "cpu_architecture": (
                     CpuArchitecture.ARM64
                     if str(server.architecture or "").upper() == "ARM64"


### PR DESCRIPTION
## Summary
- Read GCP `MachineType.architecture` from the Compute API instead of hardcoding only `t2a` as ARM64 (which left Axion `c4a`/`n4a` incorrectly marked as X86_64)
- Bump package version to **0.8.5** and document the fix in `CHANGELOG.md`

Release note: tagging `v0.8.5` after merge will trigger `.github/workflows/release.yml` (build + PyPI publish).

## Test plan
- [x] Confirm crawler output for `t2a-*`, `c4a-*`, and `n4a-*` has `cpu_architecture=arm64`
- [x] Confirm older x86 types (e.g. `n1-standard-*`, `e2-*`) still resolve to `x86_64` when `architecture` is empty
- [ ] After merge, tag `v0.8.5` and verify the release workflow publishes to PyPI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GCP CPU architecture detection.
  * Correctly identifies Arm-based machine types, including newer c4a and n4a series.
  * Prevents supported machines from being incorrectly classified as x86_64.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->