### PR TITLE
Fix GCP server_price crawl skipping newer/ARM machine series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## Unreleased
+
+Fix(es):
+
+- GCP: removed the hardcoded `SERVER_FAMILIES` allowlist that gated server pricing lookups.
+  Any machine series not on that list (e.g. Axion `C4A`/`N4A`, `C4D`/`C4N`, `G4`, `M4`, `H4D`)
+  was silently skipped from `server_price` entirely, even though its metadata (server table,
+  `cpu_architecture`, etc.) was crawled correctly. Confirmed live that the Billing Catalog
+  already has plain OnDemand/Preemptible Instance Core/Ram SKUs for all of those, matching the
+  existing description-parsing logic once let through. Families with genuinely no pricing SKUs
+  yet in the Billing Catalog (e.g. `A4X`, `M4N`, `X4`, TPU VM series as of 2026-08) are now
+  skipped gracefully (logged at DEBUG) instead of crashing the whole price crawl with an
+  `AssertionError`.
+
 ## v0.8.4 (July 28, 2026)
 
 New feature(s):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v0.8.x (development)
 
 Fix(es):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,10 @@
 
 Fix(es):
 
-- GCP: removed the hardcoded `SERVER_FAMILIES` allowlist that gated server pricing lookups.
-  Any machine series not on that list (e.g. Axion `C4A`/`N4A`, `C4D`/`C4N`, `G4`, `M4`, `H4D`)
-  was silently skipped from `server_price` entirely, even though its metadata (server table,
-  `cpu_architecture`, etc.) was crawled correctly. Confirmed live that the Billing Catalog
-  already has plain OnDemand/Preemptible Instance Core/Ram SKUs for all of those, matching the
-  existing description-parsing logic once let through. Families with genuinely no pricing SKUs
-  yet in the Billing Catalog (e.g. `A4X`, `M4N`, `X4`, TPU VM series as of 2026-08) are now
-  skipped gracefully (logged at DEBUG) instead of crashing the whole price crawl with an
-  `AssertionError`.
+- GCP: removed the hardcoded `SERVER_FAMILIES` allowlist that gated newer
+  (missed) server pricing lookups. Families with genuinely no pricing SKUs yet
+  in the Billing Catalog (e.g. `A4X`, `M4N`, `X4`, TPU VM series as of 2026-08)
+  are now skipped gracefully (logged at DEBUG) instead of throwing exception.
 - GCP: `cpu_architecture` was hardcoded to only recognize `t2a` as `ARM64`, defaulting
   every other series (including the Arm-based Axion `c4a`/`n4a`) to `X86_64`. Now reads
   the real `MachineType.architecture` API field instead.

--- a/src/sc_crawler/__init__.py
+++ b/src/sc_crawler/__init__.py
@@ -1,4 +1,4 @@
 """Spare Cores crawler: collect and standardize cloud server offerings data."""
 
-__version__ = "0.8.4"
+__version__ = "0.8.6"
 __version_info__ = tuple(int(x) for x in __version__.split(".")[:3])

--- a/src/sc_crawler/__init__.py
+++ b/src/sc_crawler/__init__.py
@@ -1,4 +1,4 @@
 """Spare Cores crawler: collect and standardize cloud server offerings data."""
 
-__version__ = "0.8.6"
+__version__ = "0.8.4"
 __version_info__ = tuple(int(x) for x in __version__.split(".")[:3])

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -152,17 +152,7 @@ STORAGE_ALLOWLIST = ["pd-standard", "pd-ssd", "pd-balanced"]
 
 
 def _server_family(server_name: str) -> str:
-    """Look up server family based on server name.
-
-    Used only to build the SKU lookup key, so this is deliberately not
-    validated against a hardcoded list of known families: that previously
-    caused e.g. Axion C4A/N4A and other newer series (which the live Billing
-    Catalog *does* have plain OnDemand/Preemptible Instance Core/Ram SKUs
-    for, confirmed live) to be silently skipped from pricing entirely,
-    despite their metadata (incl. cpu_architecture) being crawled correctly.
-    Whether pricing actually exists for the resulting family key is decided
-    downstream by the SKU dict lookup in ``_inventory_server_prices()``.
-    """
+    """Look up server family based on server name to build the SKU lookup key."""
     # example server names: f1-micro, n2d-standard-96
     return server_name.lower().split("-")[0]
 
@@ -355,9 +345,11 @@ def _inventory_server_prices(vendor: Vendor, allocation: Allocation) -> List[dic
         if not server_regions:
             # some newer/exotic families (e.g. A4X, M4N, X4, TPU VM series as of
             # 2026-08) have no Instance Core/Ram (or instance-level) SKUs at all
-            # yet in the live Billing Catalog -- skip pricing for them instead of
-            # crashing the whole crawl; their metadata is still crawled normally.
-            vendor.log(f"Skip instance: no SKU found for family '{family}' ({server.name})", DEBUG)
+            # yet in the live Billing Catalog
+            vendor.log(
+                f"Skip instance: no SKU found for family '{family}' ({server.name})",
+                DEBUG,
+            )
             continue
 
         for server_region in server_regions:

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -124,31 +124,6 @@ def _skus(service_name: str) -> List[compute_v1.types.compute.Zone]:
 # ##############################################################################
 # Internal helpers
 
-SERVER_FAMILIES = {
-    "a2",
-    "a3",
-    "c2",  # compute optimized
-    "c2d",
-    "c3",
-    "c3d",
-    "c4",
-    "e2",
-    "f1",  # micro instance running on N1
-    "g1",  # micro instance running on N1
-    "g2",
-    "h3",
-    "m1",  # memory optimized
-    "m2",  # memory optimized + premium
-    "m3",
-    "n1",
-    "n2",
-    "n2d",
-    "n4",
-    "t2a",
-    "t2d",
-    "z3",
-}
-
 # there are a few odd descriptions that needs lookup,
 # otherwise the descriptions match the server family
 SERVER_DESCRIPTION_TO_FAMILY = {
@@ -174,12 +149,19 @@ STORAGE_ALLOWLIST = ["pd-standard", "pd-ssd", "pd-balanced"]
 
 
 def _server_family(server_name: str) -> str:
-    """Look up server family based on server name"""
+    """Look up server family based on server name.
+
+    Used only to build the SKU lookup key, so this is deliberately not
+    validated against a hardcoded list of known families: that previously
+    caused e.g. Axion C4A/N4A and other newer series (which the live Billing
+    Catalog *does* have plain OnDemand/Preemptible Instance Core/Ram SKUs
+    for, confirmed live) to be silently skipped from pricing entirely,
+    despite their metadata (incl. cpu_architecture) being crawled correctly.
+    Whether pricing actually exists for the resulting family key is decided
+    downstream by the SKU dict lookup in ``_inventory_server_prices()``.
+    """
     # example server names: f1-micro, n2d-standard-96
-    prefix = server_name.lower().split("-")[0]
-    if prefix in SERVER_FAMILIES:
-        return prefix
-    raise KeyError(f"Not known server family for {server_name}")
+    return server_name.lower().split("-")[0]
 
 
 @cache
@@ -356,11 +338,7 @@ def _inventory_server_prices(vendor: Vendor, allocation: Allocation) -> List[dic
     items = []
 
     for server in vendor.servers:
-        try:
-            family = _server_family(server.name)
-        except KeyError as e:
-            vendor.log(f"Skip instance: {str(e)}", DEBUG)
-            continue
+        family = _server_family(server.name)
 
         # https://cloud.google.com/compute/docs/memory-optimized-machines#m1_series
         # N1 -> M1 rename "to more clearly identify the machines"
@@ -369,7 +347,13 @@ def _inventory_server_prices(vendor: Vendor, allocation: Allocation) -> List[dic
 
         # price per instance or cpu/ram
         server_regions = [*skus["instance"][family].keys(), *skus["cpu"][family].keys()]
-        assert len(server_regions) > 0
+        if not server_regions:
+            # some newer/exotic families (e.g. A4X, M4N, X4, TPU VM series as of
+            # 2026-08) have no Instance Core/Ram (or instance-level) SKUs at all
+            # yet in the live Billing Catalog -- skip pricing for them instead of
+            # crashing the whole crawl; their metadata is still crawled normally.
+            vendor.log(f"Skip instance: no SKU found for family '{family}' ({server.name})", DEBUG)
+            continue
 
         for server_region in server_regions:
             # skip edge regions

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -357,7 +357,10 @@ def _inventory_server_prices(vendor: Vendor, allocation: Allocation) -> List[dic
             # 2026-08) have no Instance Core/Ram (or instance-level) SKUs at all
             # yet in the live Billing Catalog -- skip pricing for them instead of
             # crashing the whole crawl; their metadata is still crawled normally.
-            vendor.log(f"Skip instance: no SKU found for family '{family}' ({server.name})", DEBUG)
+            vendor.log(
+                f"Skip instance: no SKU found for family '{family}' ({server.name})",
+                DEBUG,
+            )
             continue
 
         for server_region in server_regions:


### PR DESCRIPTION
## Summary

- `_inventory_server_prices()` called `_server_family()`, which validated the machine-type prefix (e.g. `c4a` from `c4a-standard-4`) against a hardcoded `SERVER_FAMILIES` allowlist and raised `KeyError` for anything not on it -- silently dropping that server from `server_price` entirely, even though its `server` table metadata (incl. `cpu_architecture`) was crawled correctly.
- Confirmed live against the Cloud Billing Catalog that `C4A`/`C4D`/`C4N`, `N4A`/`N4D`, `G4`, `M4` and `H4D` all already have plain `OnDemand`/`Preemptible` "Instance Core"/"Instance Ram" SKUs matching the existing description-parsing logic -- they were just never let through the allowlist. Removed the allowlist so `_server_family()` just returns the raw prefix and lets the SKU dict decide.
- A few genuinely unpriced series today (`A4X`, `M4N`, `X4`, current TPU VM types like `ct5lp`/`tpu7x`) have no matching Billing Catalog SKUs at all -- replaced the hard `assert len(server_regions) > 0` (which would otherwise crash the *entire* price crawl on the first such server) with a graceful per-instance skip, logged at `DEBUG`, matching the existing skip pattern used elsewhere in this function.

## Test plan

- [x] Full local test suite (`pytest tests/`): 103 passed.
- [x] Live-probed the GCP Cloud Billing Catalog (isolated container, real service-account credentials) for `C4A`/`C4D`/`C4N`/`N4A`/`N4D`/`A4`/`A4X`/`G4`/`M4`/`M4N`/`H4D`/`X4`/`CT3`/`CT5`/`CT6`/`TPU` SKU descriptions to confirm which families do/don't have pricing data before writing the fix.
- [x] Re-run a full GCP crawl and confirm `server_price` now has rows for `c4a`/`c4d`/`c4n`/`n4a`/`n4d`/`g4`/`m4`/`h4d`, and that the crawl still completes cleanly for `a4`/`a4x`/`m4n`/`x4`/TPU series (no `AssertionError`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GCP pricing coverage for previously skipped machine series.
  * Pricing collection now continues when a machine family has no Billing Catalog SKU, rather than failing.
  * Added debug logging for machine families without available pricing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->