### PR TITLE
Fix CPU allocation mapping and add network speed to Vultr

### DIFF
--- a/src/sc_crawler/vendors/_vultr.py
+++ b/src/sc_crawler/vendors/_vultr.py
@@ -403,9 +403,15 @@ def inventory_servers(vendor):
         cpu_model = _standardize_cpu_model(cpu_model_raw)
         vcpus = server.get("vcpu_count") or server.get("cpu_threads")
         cpu_cores = server.get("cpu_count")
+        # Plan type → CPU allocation (API has no dedicated/shared flag).
+        # Shared: vc2, vhp, vhf — https://www.vultr.com/pricing/ ("Cloud Compute" /
+        #   "These virtual machines run atop shared vCPUs")
+        # Dedicated: voc — same page ("Optimized Cloud Compute" / "fully dedicated")
+        # Dedicated: vx1 — https://docs.vultr.com/vultr-vx1-cloud-compute
+        # Dedicated: vcg, vdm, and bare metal (type SSD/NVMe from /v2/plans/metal)
         cpu_allocation = (
             CpuAllocation.SHARED
-            if server.get("vcpu_count")
+            if server.get("type") in ("vc2", "vhp", "vhf")
             else CpuAllocation.DEDICATED
         )
         cpu_architecture = (

--- a/src/sc_crawler/vendors/_vultr.py
+++ b/src/sc_crawler/vendors/_vultr.py
@@ -532,7 +532,9 @@ def inventory_servers(vendor):
             "storage_type": storage_type,
             "storages": [],
             "network_speed_baseline": None,
-            "network_speed_max": None,
+            # link_speed is Gbps when present ("up to" / provisioned; no documented baseline)
+            # link_type (shared|dedicated) is network uplink, not mapped to a column
+            "network_speed_max": server.get("link_speed"),
             "network_storage_speed_baseline": None,
             "network_storage_speed_max": None,
             "inbound_traffic": 0,


### PR DESCRIPTION
# Overview

Fix CPU allocation mapping and add network speed to `Vultr`.

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CPU allocation reporting based on Vultr plan types.
  * Added maximum network speed information from the provider’s available server data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->