### PR TITLE
Replacing server_id with resource_id and resource_type discriminator in benchmark_score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ Maintenance update:
 
 - Drop empty `database_benchmark_score`; database scores use `benchmark_score`
   with `resource_type=DATABASE`.
-- Keep legacy `server_id` / `database_id` query and insert keys via hybrid
-  properties and input-dict translation.
+- Keep `server_id` / `database_id` query and insert keys via hybrid properties 
+  and input-dict translation.
+- Ingest `pgbench` scores for database instances too.
 
 Fix(es):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
-## v0.8.x (development)
+## v0.9.0 (August 10, 2026)
+
+‼ Breaking changes:
+
+- Reshape `benchmark_score`: add `resource_type` discriminator and `resource_id`
+  (replaces `server_id`); replace `kernel_version` with an extensible
+  `environment` JSON column (e.g. `kernel_version`, `database_engine_version`).
+
+Maintenance update:
+
+- Drop empty `database_benchmark_score`; database scores use `benchmark_score`
+  with `resource_type=DATABASE`.
+- Keep legacy `server_id` / `database_id` query and insert keys via hybrid
+  properties and input-dict translation.
 
 Fix(es):
 

--- a/src/sc_crawler/__init__.py
+++ b/src/sc_crawler/__init__.py
@@ -1,4 +1,4 @@
 """Spare Cores crawler: collect and standardize cloud server offerings data."""
 
-__version__ = "0.8.5"
+__version__ = "0.9.0"
 __version_info__ = tuple(int(x) for x in __version__.split(".")[:3])

--- a/src/sc_crawler/alembic/versions/a9b0c1d2e3f4_v0_9_0_merge_benchmark_score_tables.py
+++ b/src/sc_crawler/alembic/versions/a9b0c1d2e3f4_v0_9_0_merge_benchmark_score_tables.py
@@ -456,7 +456,7 @@ def upgrade() -> None:
                 UPDATE {table_name}
                 SET environment = jsonb_build_object('kernel_version', kernel_version)
                 WHERE kernel_version IS NOT NULL
-                """
+                """  # noqa: S608
             )
         )
     else:
@@ -466,7 +466,7 @@ def upgrade() -> None:
                 UPDATE {table_name}
                 SET environment = json_object('kernel_version', kernel_version)
                 WHERE kernel_version IS NOT NULL
-                """
+                """  # noqa: S608
             )
         )
 
@@ -617,6 +617,30 @@ def downgrade() -> None:
         ),
     )
 
+    op.execute(
+        sa.text(
+            f"""
+            INSERT INTO {db_score_name} (
+                vendor_id, database_id, benchmark_id, config,
+                framework_version, score, score_breakdown, note, status, observed_at
+            )
+            SELECT
+                vendor_id, resource_id, benchmark_id, config,
+                framework_version, score, score_breakdown, note, status, observed_at
+            FROM {table_name}
+            WHERE resource_type = 'DATABASE'
+            """  # noqa: S608
+        )
+    )
+    op.execute(
+        sa.text(
+            f"""
+            DELETE FROM {table_name}
+            WHERE resource_type = 'DATABASE'
+            """  # noqa: S608
+        )
+    )
+
     op.add_column(
         table_name,
         sa.Column(
@@ -633,7 +657,7 @@ def downgrade() -> None:
                 UPDATE {table_name}
                 SET kernel_version = environment ->> 'kernel_version'
                 WHERE environment IS NOT NULL
-                """
+                """  # noqa: S608
             )
         )
     else:
@@ -643,7 +667,7 @@ def downgrade() -> None:
                 UPDATE {table_name}
                 SET kernel_version = json_extract(environment, '$.kernel_version')
                 WHERE environment IS NOT NULL
-                """
+                """  # noqa: S608
             )
         )
 

--- a/src/sc_crawler/alembic/versions/a9b0c1d2e3f4_v0_9_0_merge_benchmark_score_tables.py
+++ b/src/sc_crawler/alembic/versions/a9b0c1d2e3f4_v0_9_0_merge_benchmark_score_tables.py
@@ -1,0 +1,734 @@
+"""v0.9.0 merge database_benchmark_score into benchmark_score
+
+Revision ID: a9b0c1d2e3f4
+Revises: f97756a9e15f
+Create Date: 2026-08-10 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+import sqlmodel
+from alembic import op
+
+revision: str = "a9b0c1d2e3f4"
+down_revision: Union[str, None] = "f97756a9e15f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def is_scd_migration() -> bool:
+    return bool(op.get_context().config.attributes.get("scd"))
+
+
+def scdize_suffix(table_name: str) -> str:
+    if is_scd_migration():
+        return table_name + "_scd"
+    return table_name
+
+
+def _enum(name: str, values: tuple[str, ...]):
+    is_postgresql = op.get_context().dialect.name == "postgresql"
+    if is_postgresql:
+        return sa.dialects.postgresql.ENUM(*values, name=name, create_type=False)
+    return sa.Enum(*values, name=name)
+
+
+def get_benchmark_score_table(is_scd: bool) -> sa.Table:
+    """Pre-v0.9.0 ``benchmark_score`` schema (copy_from source)."""
+    is_postgresql = op.get_context().dialect.name == "postgresql"
+    json_type = sa.dialects.postgresql.JSONB if is_postgresql else sa.JSON
+    table_name = scdize_suffix("benchmark_score")
+    vendor_table = scdize_suffix("vendor")
+    server_table = scdize_suffix("server")
+    benchmark_table = scdize_suffix("benchmark")
+    primary_keys = (
+        ("vendor_id", "server_id", "benchmark_id", "config", "observed_at")
+        if is_scd
+        else ("vendor_id", "server_id", "benchmark_id", "config")
+    )
+    foreign_keys = (
+        (
+            sa.ForeignKeyConstraint(
+                ["benchmark_id"],
+                [f"{benchmark_table}.benchmark_id"],
+                name=op.f(f"fk_{table_name}_benchmark_id_{benchmark_table}"),
+            ),
+            sa.ForeignKeyConstraint(
+                ["vendor_id", "server_id"],
+                [f"{server_table}.vendor_id", f"{server_table}.server_id"],
+                name=op.f(f"fk_{table_name}_vendor_id_{server_table}"),
+            ),
+            sa.ForeignKeyConstraint(
+                ["vendor_id"],
+                [f"{vendor_table}.vendor_id"],
+                name=op.f(f"fk_{table_name}_vendor_id_{vendor_table}"),
+            ),
+        )
+        if not is_scd
+        else ()
+    )
+    return sa.Table(
+        table_name,
+        sa.MetaData(),
+        sa.Column(
+            "vendor_id",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            comment="Reference to the Vendor.",
+        ),
+        sa.Column(
+            "server_id",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            comment="Reference to the Server.",
+        ),
+        sa.Column(
+            "benchmark_id",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            comment="Reference to the Benchmark.",
+        ),
+        sa.Column(
+            "config",
+            json_type(),
+            nullable=False,
+            comment=(
+                "Dictionary of config parameters of the specific benchmark, "
+                'e.g. {"bandwidth": 4096}'
+            ),
+        ),
+        sa.Column(
+            "framework_version",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            comment="The version of the benchmark tool used.",
+        ),
+        sa.Column(
+            "kernel_version",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            comment="The kernel version of the server when the benchmark was run.",
+        ),
+        sa.Column(
+            "score",
+            sa.Float(),
+            nullable=False,
+            comment="The resulting score of the benchmark.",
+        ),
+        sa.Column(
+            "score_breakdown",
+            json_type(),
+            nullable=True,
+            comment=(
+                "Structured derivation of composite scores (e.g. workload profiles): "
+                "per-component raw values, references, normalized values, weights, and "
+                "coverage. Null for simple benchmark scores."
+            ),
+        ),
+        sa.Column(
+            "note",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            comment="Optional note, comment or context on the benchmark score.",
+        ),
+        sa.Column(
+            "status",
+            _enum("status", ("ACTIVE", "INACTIVE")),
+            nullable=False,
+            comment="Status of the resource (active or inactive).",
+        ),
+        sa.Column(
+            "observed_at",
+            sa.DateTime(),
+            nullable=False,
+            comment="Timestamp of the last observation.",
+        ),
+        *foreign_keys,
+        sa.PrimaryKeyConstraint(*primary_keys, name=op.f(f"pk_{table_name}")),
+        comment=(
+            "SCD version of .tables.BenchmarkScore."
+            if is_scd
+            else "Results of running Benchmark scenarios on Servers."
+        ),
+    )
+
+
+def get_benchmark_score_table_mid(is_scd: bool) -> sa.Table:
+    """Mid-upgrade schema: resource_* + environment, still has kernel_version."""
+    is_postgresql = op.get_context().dialect.name == "postgresql"
+    json_type = sa.dialects.postgresql.JSONB if is_postgresql else sa.JSON
+    table_name = scdize_suffix("benchmark_score")
+    vendor_table = scdize_suffix("vendor")
+    benchmark_table = scdize_suffix("benchmark")
+    primary_keys = (
+        (
+            "vendor_id",
+            "benchmark_id",
+            "resource_type",
+            "resource_id",
+            "config",
+            "observed_at",
+        )
+        if is_scd
+        else (
+            "vendor_id",
+            "benchmark_id",
+            "resource_type",
+            "resource_id",
+            "config",
+        )
+    )
+    foreign_keys = (
+        (
+            sa.ForeignKeyConstraint(
+                ["benchmark_id"],
+                [f"{benchmark_table}.benchmark_id"],
+                name=op.f(f"fk_{table_name}_benchmark_id_{benchmark_table}"),
+            ),
+            sa.ForeignKeyConstraint(
+                ["vendor_id"],
+                [f"{vendor_table}.vendor_id"],
+                name=op.f(f"fk_{table_name}_vendor_id_{vendor_table}"),
+            ),
+        )
+        if not is_scd
+        else ()
+    )
+    return sa.Table(
+        table_name,
+        sa.MetaData(),
+        sa.Column(
+            "vendor_id",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            comment="Reference to the Vendor.",
+        ),
+        sa.Column(
+            "benchmark_id",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            comment="Reference to the Benchmark.",
+        ),
+        sa.Column(
+            "resource_type",
+            _enum("resourcetype", ("SERVER", "DATABASE")),
+            nullable=False,
+            comment="Kind of resource the score refers to.",
+        ),
+        sa.Column(
+            "resource_id",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            comment="Reference to the resource (see resource_type).",
+        ),
+        sa.Column(
+            "config",
+            json_type(),
+            nullable=False,
+            comment=(
+                "Dictionary of config parameters of the specific benchmark, "
+                'e.g. {"bandwidth": 4096}'
+            ),
+        ),
+        sa.Column(
+            "framework_version",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            comment="The version of the benchmark tool used.",
+        ),
+        sa.Column(
+            "kernel_version",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            comment="The kernel version of the server when the benchmark was run.",
+        ),
+        sa.Column(
+            "environment",
+            json_type(),
+            nullable=True,
+            comment=(
+                "Extensible environment details "
+                "(e.g. kernel_version, database_engine_version)."
+            ),
+        ),
+        sa.Column(
+            "score",
+            sa.Float(),
+            nullable=False,
+            comment="The resulting score of the benchmark.",
+        ),
+        sa.Column(
+            "score_breakdown",
+            json_type(),
+            nullable=True,
+            comment=(
+                "Structured derivation of composite scores (e.g. workload profiles): "
+                "per-component raw values, references, normalized values, weights, and "
+                "coverage. Null for simple benchmark scores."
+            ),
+        ),
+        sa.Column(
+            "note",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            comment="Optional note, comment or context on the benchmark score.",
+        ),
+        sa.Column(
+            "status",
+            _enum("status", ("ACTIVE", "INACTIVE")),
+            nullable=False,
+            comment="Status of the resource (active or inactive).",
+        ),
+        sa.Column(
+            "observed_at",
+            sa.DateTime(),
+            nullable=False,
+            comment="Timestamp of the last observation.",
+        ),
+        *foreign_keys,
+        sa.PrimaryKeyConstraint(*primary_keys, name=op.f(f"pk_{table_name}")),
+        comment=(
+            "SCD version of .tables.BenchmarkScore."
+            if is_scd
+            else "Results of running Benchmark scenarios on Servers or managed Databases."
+        ),
+    )
+
+
+def upgrade() -> None:
+    is_scd = is_scd_migration()
+    is_postgresql = op.get_context().dialect.name == "postgresql"
+    json_type = sa.dialects.postgresql.JSONB if is_postgresql else sa.JSON
+    table_name = scdize_suffix("benchmark_score")
+    table = get_benchmark_score_table(is_scd)
+    db_score_name = scdize_suffix("database_benchmark_score")
+    server_table = scdize_suffix("server")
+    do_recreate_tables = (op.get_context().dialect.name == "sqlite") or is_scd
+
+    resource_type_comment = "Kind of resource the score refers to."
+    resource_id_comment = "Reference to the resource (see resource_type)."
+    environment_comment = (
+        "Extensible environment details (e.g. kernel_version, database_engine_version)."
+    )
+
+    # Existing rows are server scores.
+    _upgrade_column_order = (
+        "vendor_id",
+        "benchmark_id",
+        "resource_type",
+        "server_id",  # → resource_id
+        "config",
+        "framework_version",
+        "kernel_version",
+        "environment",
+        "score",
+        "score_breakdown",
+        "note",
+        "status",
+        "observed_at",
+    )
+    primary_keys = (
+        (
+            "vendor_id",
+            "benchmark_id",
+            "resource_type",
+            "resource_id",
+            "config",
+            "observed_at",
+        )
+        if is_scd
+        else (
+            "vendor_id",
+            "benchmark_id",
+            "resource_type",
+            "resource_id",
+            "config",
+        )
+    )
+    # batch_alter keeps the pre-rename column key after rename; PK cols must use that key.
+    batch_primary_keys = (
+        (
+            "vendor_id",
+            "benchmark_id",
+            "resource_type",
+            "server_id",
+            "config",
+            "observed_at",
+        )
+        if is_scd
+        else (
+            "vendor_id",
+            "benchmark_id",
+            "resource_type",
+            "server_id",
+            "config",
+        )
+    )
+
+    if do_recreate_tables:
+        with op.batch_alter_table(
+            table_name,
+            schema=None,
+            copy_from=table,
+            recreate="always",
+            partial_reordering=[_upgrade_column_order],
+        ) as batch_op:
+            batch_op.add_column(
+                sa.Column(
+                    "resource_type",
+                    sa.Enum("SERVER", "DATABASE", name="resourcetype"),
+                    nullable=False,
+                    server_default="SERVER",
+                    comment=resource_type_comment,
+                ),
+            )
+            batch_op.alter_column(
+                "server_id",
+                new_column_name="resource_id",
+                comment=resource_id_comment,
+            )
+            batch_op.add_column(
+                sa.Column(
+                    "environment",
+                    json_type(),
+                    nullable=True,
+                    comment=environment_comment,
+                ),
+            )
+            if not is_scd:
+                batch_op.drop_constraint(
+                    op.f(f"fk_{table_name}_vendor_id_{server_table}"),
+                    type_="foreignkey",
+                )
+            batch_op.drop_constraint(op.f(f"pk_{table_name}"), type_="primary")
+            batch_op.create_primary_key(
+                op.f(f"pk_{table_name}"), list(batch_primary_keys)
+            )
+    else:
+        # batch_alter creates new enums; create explicitly only when not recreating.
+        if is_postgresql:
+            sa.Enum("SERVER", "DATABASE", name="resourcetype").create(
+                op.get_bind(), checkfirst=True
+            )
+        op.add_column(
+            table_name,
+            sa.Column(
+                "resource_type",
+                _enum("resourcetype", ("SERVER", "DATABASE")),
+                nullable=False,
+                server_default="SERVER",
+                comment=resource_type_comment,
+            ),
+        )
+        op.alter_column(
+            table_name,
+            "server_id",
+            new_column_name="resource_id",
+            comment=resource_id_comment,
+        )
+        op.add_column(
+            table_name,
+            sa.Column(
+                "environment",
+                json_type(),
+                nullable=True,
+                comment=environment_comment,
+            ),
+        )
+        op.drop_constraint(
+            op.f(f"fk_{table_name}_vendor_id_{server_table}"),
+            table_name,
+            type_="foreignkey",
+        )
+        op.drop_constraint(op.f(f"pk_{table_name}"), table_name, type_="primary")
+        op.create_primary_key(
+            op.f(f"pk_{table_name}"),
+            table_name,
+            list(primary_keys),
+        )
+
+    if is_postgresql:
+        op.execute(
+            sa.text(
+                f"""
+                UPDATE {table_name}
+                SET environment = jsonb_build_object('kernel_version', kernel_version)
+                WHERE kernel_version IS NOT NULL
+                """
+            )
+        )
+    else:
+        op.execute(
+            sa.text(
+                f"""
+                UPDATE {table_name}
+                SET environment = json_object('kernel_version', kernel_version)
+                WHERE kernel_version IS NOT NULL
+                """
+            )
+        )
+
+    if do_recreate_tables and not is_postgresql:
+        with op.batch_alter_table(
+            table_name,
+            schema=None,
+            copy_from=get_benchmark_score_table_mid(is_scd),
+            recreate="always",
+        ) as batch_op:
+            batch_op.drop_column("kernel_version")
+            batch_op.alter_column("resource_type", server_default=None)
+    else:
+        op.drop_column(table_name, "kernel_version")
+        if is_postgresql:
+            op.alter_column(
+                table_name,
+                "resource_type",
+                server_default=None,
+                existing_nullable=False,
+            )
+
+    if is_postgresql:
+        op.execute(
+            sa.text(
+                f"COMMENT ON TABLE {table_name} IS "
+                "'Results of running Benchmark scenarios on Servers or managed Databases.'"
+            )
+        )
+
+    op.drop_table(db_score_name)
+
+
+def downgrade() -> None:
+    is_scd = is_scd_migration()
+    is_postgresql = op.get_context().dialect.name == "postgresql"
+    json_type = sa.dialects.postgresql.JSONB if is_postgresql else sa.JSON
+    table_name = scdize_suffix("benchmark_score")
+    db_score_name = scdize_suffix("database_benchmark_score")
+    vendor_table = scdize_suffix("vendor")
+    server_table = scdize_suffix("server")
+    database_table = scdize_suffix("database")
+    benchmark_table = scdize_suffix("benchmark")
+    do_recreate_tables = (op.get_context().dialect.name == "sqlite") or is_scd
+
+    op.create_table(
+        db_score_name,
+        sa.Column(
+            "vendor_id",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            comment="Reference to the Vendor.",
+        ),
+        sa.Column(
+            "database_id",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            comment="Reference to the Database.",
+        ),
+        sa.Column(
+            "benchmark_id",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=False,
+            comment="Reference to the Benchmark.",
+        ),
+        sa.Column(
+            "config",
+            json_type(),
+            nullable=False,
+            comment=(
+                "Dictionary of config parameters of the specific benchmark, "
+                'e.g. {"bandwidth": 4096}'
+            ),
+        ),
+        sa.Column(
+            "framework_version",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            comment="The version of the benchmark tool used.",
+        ),
+        sa.Column(
+            "score",
+            sa.Float(),
+            nullable=False,
+            comment="The resulting score of the benchmark.",
+        ),
+        sa.Column(
+            "score_breakdown",
+            json_type(),
+            nullable=True,
+            comment=(
+                "Structured derivation of composite scores (e.g. workload profiles): "
+                "per-component raw values, references, normalized values, weights, and "
+                "coverage. Null for simple benchmark scores."
+            ),
+        ),
+        sa.Column(
+            "note",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            comment="Optional note, comment or context on the benchmark score.",
+        ),
+        sa.Column(
+            "status",
+            _enum("status", ("ACTIVE", "INACTIVE")),
+            nullable=False,
+            comment="Status of the resource (active or inactive).",
+        ),
+        sa.Column(
+            "observed_at",
+            sa.DateTime(),
+            nullable=False,
+            comment="Timestamp of the last observation.",
+        ),
+        *(
+            ()
+            if is_scd
+            else (
+                sa.ForeignKeyConstraint(
+                    ["benchmark_id"],
+                    [f"{benchmark_table}.benchmark_id"],
+                    name=op.f(f"fk_{db_score_name}_benchmark_id_{benchmark_table}"),
+                ),
+                sa.ForeignKeyConstraint(
+                    ["vendor_id", "database_id"],
+                    [f"{database_table}.vendor_id", f"{database_table}.database_id"],
+                    name=op.f(f"fk_{db_score_name}_vendor_id_{database_table}"),
+                ),
+                sa.ForeignKeyConstraint(
+                    ["vendor_id"],
+                    [f"{vendor_table}.vendor_id"],
+                    name=op.f(f"fk_{db_score_name}_vendor_id_{vendor_table}"),
+                ),
+            )
+        ),
+        sa.PrimaryKeyConstraint(
+            *(
+                ("vendor_id", "database_id", "benchmark_id", "config", "observed_at")
+                if is_scd
+                else ("vendor_id", "database_id", "benchmark_id", "config")
+            ),
+            name=op.f(f"pk_{db_score_name}"),
+        ),
+        comment=(
+            "SCD version of .tables.DatabaseBenchmarkScore."
+            if is_scd
+            else "Results of running Benchmark scenarios on managed Databases."
+        ),
+    )
+
+    op.add_column(
+        table_name,
+        sa.Column(
+            "kernel_version",
+            sqlmodel.sql.sqltypes.AutoString(),
+            nullable=True,
+            comment="The kernel version of the server when the benchmark was run.",
+        ),
+    )
+    if is_postgresql:
+        op.execute(
+            sa.text(
+                f"""
+                UPDATE {table_name}
+                SET kernel_version = environment ->> 'kernel_version'
+                WHERE environment IS NOT NULL
+                """
+            )
+        )
+    else:
+        op.execute(
+            sa.text(
+                f"""
+                UPDATE {table_name}
+                SET kernel_version = json_extract(environment, '$.kernel_version')
+                WHERE environment IS NOT NULL
+                """
+            )
+        )
+
+    _downgrade_column_order = (
+        "vendor_id",
+        "resource_id",  # → server_id
+        "benchmark_id",
+        "config",
+        "framework_version",
+        "kernel_version",
+        "score",
+        "score_breakdown",
+        "note",
+        "status",
+        "observed_at",
+    )
+    primary_keys = (
+        ("vendor_id", "server_id", "benchmark_id", "config", "observed_at")
+        if is_scd
+        else ("vendor_id", "server_id", "benchmark_id", "config")
+    )
+    # batch_alter keeps the pre-rename column key after rename; PK/FK cols must use that key.
+    batch_primary_keys = (
+        ("vendor_id", "resource_id", "benchmark_id", "config", "observed_at")
+        if is_scd
+        else ("vendor_id", "resource_id", "benchmark_id", "config")
+    )
+    table_mid = get_benchmark_score_table_mid(is_scd)
+
+    if do_recreate_tables:
+        with op.batch_alter_table(
+            table_name,
+            schema=None,
+            copy_from=table_mid,
+            recreate="always",
+            partial_reordering=[_downgrade_column_order],
+        ) as batch_op:
+            batch_op.drop_column("environment")
+            batch_op.drop_column("resource_type")
+            batch_op.alter_column(
+                "resource_id",
+                new_column_name="server_id",
+                comment="Reference to the Server.",
+            )
+            batch_op.drop_constraint(op.f(f"pk_{table_name}"), type_="primary")
+            batch_op.create_primary_key(
+                op.f(f"pk_{table_name}"), list(batch_primary_keys)
+            )
+            if not is_scd:
+                batch_op.create_foreign_key(
+                    op.f(f"fk_{table_name}_vendor_id_{server_table}"),
+                    server_table,
+                    ["vendor_id", "resource_id"],
+                    ["vendor_id", "server_id"],
+                )
+    else:
+        # Drop PK before removing/renaming PK columns (PG CASCADE on drop_column
+        # would remove pk_benchmark_score and a later drop_constraint would fail).
+        op.drop_constraint(op.f(f"pk_{table_name}"), table_name, type_="primary")
+        op.drop_column(table_name, "environment")
+        op.drop_column(table_name, "resource_type")
+        op.alter_column(
+            table_name,
+            "resource_id",
+            new_column_name="server_id",
+            comment="Reference to the Server.",
+        )
+        op.create_primary_key(
+            op.f(f"pk_{table_name}"),
+            table_name,
+            list(primary_keys),
+        )
+        op.create_foreign_key(
+            op.f(f"fk_{table_name}_vendor_id_{server_table}"),
+            table_name,
+            server_table,
+            ["vendor_id", "server_id"],
+            ["vendor_id", "server_id"],
+        )
+
+    if is_postgresql:
+        op.execute(
+            sa.text(
+                f"COMMENT ON TABLE {table_name} IS "
+                "'Results of running Benchmark scenarios on Servers.'"
+            )
+        )
+        sa.Enum(name="resourcetype").drop(op.get_bind(), checkfirst=True)

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -31,7 +31,7 @@ from .table_bases import ServerBase
 from .table_fields import DdrGeneration, Disk, Parallelism, StorageType
 
 if TYPE_CHECKING:
-    from .tables import Server
+    from .tables import Database, Server
 
 SERVER_CLIENT_FRAMEWORK_MAPS = {
     "static_web": {
@@ -71,7 +71,7 @@ PASSMARK_MAPS = {
 
 
 @cache
-def inspector_data_path() -> str | PathLike:
+def inspector_data_path(dir_name: str = "data") -> str | PathLike:
     """Download current inspector data into a temp folder.
 
     Setting the `SC_CRAWLER_INSPECTOR_DATA_PATH` environment variable will
@@ -92,7 +92,7 @@ def inspector_data_path() -> str | PathLike:
             f.write(response.content)
         with ZipFile(zip_path, "r") as zip_ref:
             zip_ref.extractall(temp_dir)
-    return path.join(temp_dir, "sc-inspector-data-main", "data")
+    return path.join(temp_dir, "sc-inspector-data-main", dir_name)
 
 
 def _server_ids(server: "Server") -> dict:
@@ -101,6 +101,16 @@ def _server_ids(server: "Server") -> dict:
 
 def _server_path(server: "Server") -> str | PathLike:
     return path.join(inspector_data_path(), server.vendor_id, server.api_reference)
+
+
+def _database_ids(database: "Database") -> dict:
+    return {"vendor_id": database.vendor_id, "database_id": database.database_id}
+
+
+def _database_path(database: "Database") -> str | PathLike:
+    return path.join(
+        inspector_data_path("dbaas"), database.vendor_id, database.api_reference
+    )
 
 
 def _get_server_framework_run_ids(server: "Server", framework: str) -> List[str]:
@@ -126,12 +136,42 @@ def _server_framework_path(
     return path.join(*path_parts)
 
 
+def _database_framework_path(
+    database: "Database", framework: str, relpath: str | list[str] | None = None
+) -> str | PathLike:
+    path_extra_parts = ["postgres", "18", "standalone"]
+    path_parts = (
+        [_database_path(database), *path_extra_parts, framework, *relpath]
+        if isinstance(relpath, list)
+        else [
+            _database_path(database),
+            *path_extra_parts,
+            framework,
+            relpath,
+        ]
+    )
+    path_parts = [path_part for path_part in path_parts if path_part is not None]
+    return path.join(*path_parts)
+
+
 def _server_framework_stdout_path(server: "Server", framework: str) -> str | PathLike:
     return _server_framework_path(server, framework, "stdout")
 
 
+def _database_framework_stdout_path(
+    database: "Database", framework: str
+) -> str | PathLike:
+    return _database_framework_path(database, framework, "stdout")
+
+
 def _server_framework_stderr_path(server: "Server", framework: str) -> str | PathLike:
     return _server_framework_path(server, framework, "stderr")
+
+
+def _database_framework_stderr_path(
+    database: "Database", framework: str
+) -> str | PathLike:
+    return _database_framework_path(database, framework, "stderr")
 
 
 def _server_framework_stdout_from_json(server: "Server", framework: str) -> dict:
@@ -139,8 +179,18 @@ def _server_framework_stdout_from_json(server: "Server", framework: str) -> dict
         return json.load(fp)
 
 
+def _database_framework_stdout_from_json(database: "Database", framework: str) -> dict:
+    with open(_database_framework_stdout_path(database, framework), "r") as fp:
+        return json.load(fp)
+
+
 def _server_framework_meta(server: "Server", framework: str) -> dict:
     with open(_server_framework_path(server, framework, "meta.json"), "r") as fp:
+        return json.load(fp)
+
+
+def _database_framework_meta(database: "Database", framework: str) -> dict:
+    with open(_database_framework_path(database, framework, "meta.json"), "r") as fp:
         return json.load(fp)
 
 
@@ -242,14 +292,20 @@ def _server_average_time_to_start(server: "Server") -> float | None:
     return round(sum(durations) / len(durations), 2) if durations else None
 
 
-def _observed_at(server: "Server", framework: str) -> dict:
-    ts = _server_framework_meta(server, framework)["end"]
+def _observed_at(resource: "Server" | "Database", framework: str) -> dict:
+    if isinstance(resource, ServerBase):
+        ts = _server_framework_meta(resource, framework)["end"]
+    else:
+        ts = _database_framework_meta(resource, framework)["end"]
     assert ts is not None
     return {"observed_at": ts}
 
 
-def _framework_version(server: "Server", framework: str) -> dict:
-    framework_version = _server_framework_meta(server, framework).get("version")
+def _framework_version(resource: "Server" | "Database", framework: str) -> dict:
+    if isinstance(resource, ServerBase):
+        framework_version = _server_framework_meta(resource, framework).get("version")
+    else:
+        framework_version = _database_framework_meta(resource, framework).get("version")
     return (
         {"framework_version": framework_version}
         if framework_version is not None
@@ -257,8 +313,15 @@ def _framework_version(server: "Server", framework: str) -> dict:
     )
 
 
-def _kernel_version(server: "Server", framework: str) -> dict:
-    kernel_version = _server_framework_meta(server, framework).get("kernel_version")
+def _kernel_version(resource: "Server" | "Database", framework: str) -> dict:
+    if isinstance(resource, ServerBase):
+        kernel_version = _server_framework_meta(resource, framework).get(
+            "kernel_version"
+        )
+    else:
+        kernel_version = _database_framework_meta(resource, framework).get(
+            "kernel_version"
+        )
     return (
         {"environment": {"kernel_version": kernel_version}}
         if kernel_version is not None
@@ -267,13 +330,14 @@ def _kernel_version(server: "Server", framework: str) -> dict:
 
 
 def _benchmark_metafields(
-    server: "Server",
+    resource: "Server" | "Database",
     framework: str | None = None,
     benchmark_id: str | None = None,
     framework_version_fallback: str | dict | None = None,
     kernel_version_fallback: str | dict | None = None,
     override_framework_version: bool = False,
     override_kernel_version: bool = False,
+    extend_environment: dict | None = None,
 ) -> dict:
     if benchmark_id is None:
         if framework is None:
@@ -281,8 +345,8 @@ def _benchmark_metafields(
         benchmark_id = framework
     if framework is None:
         framework = benchmark_id.split(":")[0]
-    framework_version = _framework_version(server, framework)
-    kernel_version = _kernel_version(server, framework)
+    framework_version = _framework_version(resource, framework)
+    kernel_version = _kernel_version(resource, framework)
     if framework_version_fallback and (
         override_framework_version or not framework_version
     ):
@@ -297,9 +361,15 @@ def _benchmark_metafields(
             if isinstance(kernel_version_fallback, str)
             else {"environment": kernel_version_fallback}
         )
+    if extend_environment:
+        kernel_version["environment"].update(extend_environment)
+    if isinstance(resource, ServerBase):
+        _resource_ids = _server_ids(resource)
+    else:
+        _resource_ids = _database_ids(resource)
     return {
-        **_server_ids(server),
-        **_observed_at(server, framework),
+        **_resource_ids,
+        **_observed_at(resource, framework),
         **framework_version,
         **kernel_version,
         "benchmark_id": benchmark_id,
@@ -795,6 +865,57 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
             )
     except Exception as e:
         _log_cannot_load_benchmarks(server, framework_path, e, True)
+
+    return benchmarks
+
+
+def inspect_database_benchmarks(database: "Database") -> list[dict]:
+    benchmarks = []
+
+    framework = "pgbench"
+    framework_path = framework + "_postgres_dbaas_ro_durable"
+    try:
+        with open(
+            _database_framework_stdout_path(database, framework_path),
+            "r",
+        ) as fp:
+            data = json.load(fp)
+            measurement = "heavy_read_only"
+            profiles = data["sizes"][0]["profile"]
+            single_profile: dict = next((p for p in profiles if p["concurrency"] == 1))
+            database_engine_version = data["postgres"]["server_version"]
+            benchmarks.extend(
+                [
+                    {
+                        **_benchmark_metafields(
+                            database,
+                            framework=framework_path,
+                            benchmark_id=":".join([framework, measurement]),
+                            extend_environment={
+                                "database_engine_version": database_engine_version
+                            },
+                        ),
+                        "config": {"concurrency": "single"},
+                        "score": single_profile["score"],
+                        "note": f"Latency: {single_profile['latency_avg_ms']} ms.",
+                    },
+                    {
+                        **_benchmark_metafields(
+                            database,
+                            framework=framework_path,
+                            benchmark_id=":".join([framework, measurement]),
+                            extend_environment={
+                                "database_engine_version": database_engine_version
+                            },
+                        ),
+                        "config": {"concurrency": "peak"},
+                        "score": data["score"],
+                        "note": f"Latency: {data['latency_avg_ms']} ms, concurrency: {data['peak_concurrency']}.",
+                    },
+                ]
+            )
+    except Exception as e:
+        _log_cannot_load_benchmarks(database, framework_path, e, True)
 
     return benchmarks
 

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -259,7 +259,11 @@ def _framework_version(server: "Server", framework: str) -> dict:
 
 def _kernel_version(server: "Server", framework: str) -> dict:
     kernel_version = _server_framework_meta(server, framework).get("kernel_version")
-    return {"kernel_version": kernel_version} if kernel_version is not None else {}
+    return (
+        {"environment": {"kernel_version": kernel_version}}
+        if kernel_version is not None
+        else {}
+    )
 
 
 def _benchmark_metafields(
@@ -289,9 +293,9 @@ def _benchmark_metafields(
         )
     if kernel_version_fallback and (override_kernel_version or not kernel_version):
         kernel_version = (
-            {"kernel_version": kernel_version_fallback}
+            {"environment": {"kernel_version": kernel_version_fallback}}
             if isinstance(kernel_version_fallback, str)
-            else kernel_version_fallback
+            else {"environment": kernel_version_fallback}
         )
     return {
         **_server_ids(server),

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -852,30 +852,22 @@ def _pgbench_benchmark_scores(
             measurement = "heavy_read_only"
             profiles = data["sizes"][0]["profile"]
             single_profile: dict = next((p for p in profiles if p["concurrency"] == 1))
-            database_engine_version = data["postgres"]["server_version"]
+            database_engine_version = data["postgres"]["server_version"].split()[0]
+            benchmark_metafields = _benchmark_metafields(
+                resource,
+                framework=framework_path,
+                benchmark_id=":".join([framework, measurement]),
+                extend_environment={"database_engine_version": database_engine_version},
+            )
             return [
                 {
-                    **_benchmark_metafields(
-                        resource,
-                        framework=framework_path,
-                        benchmark_id=":".join([framework, measurement]),
-                        extend_environment={
-                            "database_engine_version": database_engine_version
-                        },
-                    ),
+                    **benchmark_metafields,
                     "config": {"concurrency": "single"},
                     "score": single_profile["score"],
                     "note": f"Latency: {single_profile['latency_avg_ms']} ms.",
                 },
                 {
-                    **_benchmark_metafields(
-                        resource,
-                        framework=framework_path,
-                        benchmark_id=":".join([framework, measurement]),
-                        extend_environment={
-                            "database_engine_version": database_engine_version
-                        },
-                    ),
+                    **benchmark_metafields,
                     "config": {"concurrency": "peak"},
                     "score": data["score"],
                     "note": f"Latency: {data['latency_avg_ms']} ms, concurrency: {data['peak_concurrency']}.",
@@ -887,6 +879,7 @@ def _pgbench_benchmark_scores(
 
 
 def inspect_database_benchmarks(database: "Database") -> list[dict]:
+    """Generate a list of BenchmarkScore-like dicts for the Database."""
     return _pgbench_benchmark_scores(
         database, framework_path_postfix="_postgres_dbaas_ro_durable"
     )

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -13,7 +13,7 @@ from re import compile, match, search, sub
 from shutil import rmtree
 from statistics import mode
 from tempfile import mkdtemp
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Union
 from zipfile import ZipFile
 
 from requests import get
@@ -292,7 +292,7 @@ def _server_average_time_to_start(server: "Server") -> float | None:
     return round(sum(durations) / len(durations), 2) if durations else None
 
 
-def _observed_at(resource: "Server" | "Database", framework: str) -> dict:
+def _observed_at(resource: Union["Server", "Database"], framework: str) -> dict:
     if isinstance(resource, ServerBase):
         ts = _server_framework_meta(resource, framework)["end"]
     else:
@@ -301,7 +301,7 @@ def _observed_at(resource: "Server" | "Database", framework: str) -> dict:
     return {"observed_at": ts}
 
 
-def _framework_version(resource: "Server" | "Database", framework: str) -> dict:
+def _framework_version(resource: Union["Server", "Database"], framework: str) -> dict:
     if isinstance(resource, ServerBase):
         framework_version = _server_framework_meta(resource, framework).get("version")
     else:
@@ -313,7 +313,7 @@ def _framework_version(resource: "Server" | "Database", framework: str) -> dict:
     )
 
 
-def _kernel_version(resource: "Server" | "Database", framework: str) -> dict:
+def _kernel_version(resource: ["Server", "Database"], framework: str) -> dict:
     if isinstance(resource, ServerBase):
         kernel_version = _server_framework_meta(resource, framework).get(
             "kernel_version"
@@ -330,7 +330,7 @@ def _kernel_version(resource: "Server" | "Database", framework: str) -> dict:
 
 
 def _benchmark_metafields(
-    resource: "Server" | "Database",
+    resource: Union["Server", "Database"],
     framework: str | None = None,
     benchmark_id: str | None = None,
     framework_version_fallback: str | dict | None = None,

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -362,7 +362,7 @@ def _benchmark_metafields(
             else {"environment": kernel_version_fallback}
         )
     if extend_environment:
-        kernel_version["environment"].update(extend_environment)
+        kernel_version.setdefault("environment", {}).update(extend_environment)
     if isinstance(resource, ServerBase):
         _resource_ids = _server_ids(resource)
     else:

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -71,12 +71,8 @@ PASSMARK_MAPS = {
 
 
 @cache
-def inspector_data_path(dir_name: str = "data") -> str | PathLike:
-    """Download current inspector data into a temp folder.
-
-    Setting the `SC_CRAWLER_INSPECTOR_DATA_PATH` environment variable will
-    override the default path for persistent/cached inspector data access.
-    """
+def _inspector_data_root() -> str | PathLike:
+    """Download current inspector data into a temp folder once per process."""
     if getenv("SC_CRAWLER_INSPECTOR_DATA_PATH"):
         temp_dir = getenv("SC_CRAWLER_INSPECTOR_DATA_PATH")
         makedirs(temp_dir, exist_ok=True)
@@ -92,7 +88,12 @@ def inspector_data_path(dir_name: str = "data") -> str | PathLike:
             f.write(response.content)
         with ZipFile(zip_path, "r") as zip_ref:
             zip_ref.extractall(temp_dir)
-    return path.join(temp_dir, "sc-inspector-data-main", dir_name)
+    return path.join(temp_dir, "sc-inspector-data-main")
+
+
+def inspector_data_path(dir_name: str = "data") -> str | PathLike:
+    """Return a subpath under the cached inspector data root."""
+    return path.join(_inspector_data_root(), dir_name)
 
 
 def _server_ids(server: "Server") -> dict:
@@ -314,12 +315,9 @@ def _framework_version(resource: Union["Server", "Database"], framework: str) ->
 
 
 def _kernel_version(resource: ["Server", "Database"], framework: str) -> dict:
+    kernel_version = None
     if isinstance(resource, ServerBase):
         kernel_version = _server_framework_meta(resource, framework).get(
-            "kernel_version"
-        )
-    else:
-        kernel_version = _database_framework_meta(resource, framework).get(
             "kernel_version"
         )
     return (
@@ -386,12 +384,14 @@ def _extract_line_from_file(file_path: str | PathLike, pattern: str) -> str | No
     return None
 
 
-def _log_cannot_load_benchmarks(server: "Server", benchmark_id, e, exc_info=False):
+def _log_cannot_load_benchmarks(
+    resource: Union["Server", "Database"], benchmark_id, e, exc_info=False
+):
     logger.debug(
         "%s benchmark(s) not loaded for %s/%s: %s",
         benchmark_id,
-        server.vendor_id,
-        server.api_reference,
+        resource.vendor_id,
+        resource.api_reference,
         e,
         stacklevel=2,
         exc_info=exc_info,
@@ -828,96 +828,68 @@ def inspect_server_benchmarks(server: "Server") -> List[dict]:
     except Exception as e:
         _log_cannot_load_benchmarks(server, framework, e, True)
 
-    framework = "pgbench"
-    framework_path = framework + "_postgres_multi_ro_durable"
-    try:
-        with open(
-            _server_framework_stdout_path(server, framework_path),
-            "r",
-        ) as fp:
-            data = json.load(fp)
-            measurement = "heavy_read_only"
-            profiles = data["sizes"][0]["profile"]
-            single_profile: dict = next((p for p in profiles if p["concurrency"] == 1))
-            benchmarks.extend(
-                [
-                    {
-                        **_benchmark_metafields(
-                            server,
-                            framework=framework_path,
-                            benchmark_id=":".join([framework, measurement]),
-                        ),
-                        "config": {"concurrency": "single"},
-                        "score": single_profile["score"],
-                        "note": f"Latency: {single_profile['latency_avg_ms']} ms.",
-                    },
-                    {
-                        **_benchmark_metafields(
-                            server,
-                            framework=framework_path,
-                            benchmark_id=":".join([framework, measurement]),
-                        ),
-                        "config": {"concurrency": "peak"},
-                        "score": data["score"],
-                        "note": f"Latency: {data['latency_avg_ms']} ms, concurrency: {data['peak_concurrency']}.",
-                    },
-                ]
-            )
-    except Exception as e:
-        _log_cannot_load_benchmarks(server, framework_path, e, True)
+    # add server related pgbench benchmark scores
+    benchmarks.extend(_pgbench_benchmark_scores(server))
 
     return benchmarks
 
 
-def inspect_database_benchmarks(database: "Database") -> list[dict]:
-    benchmarks = []
-
+def _pgbench_benchmark_scores(
+    resource: Union["Server", "Database"],
+    framework_path_postfix: str = "_postgres_multi_ro_durable",
+) -> list[dict]:
     framework = "pgbench"
-    framework_path = framework + "_postgres_dbaas_ro_durable"
+    framework_path = framework + framework_path_postfix
+    if isinstance(resource, ServerBase):
+        framework_stdout_path = _server_framework_stdout_path(resource, framework_path)
+    else:
+        framework_stdout_path = _database_framework_stdout_path(
+            resource, framework_path
+        )
     try:
-        with open(
-            _database_framework_stdout_path(database, framework_path),
-            "r",
-        ) as fp:
+        with open(framework_stdout_path, "r") as fp:
             data = json.load(fp)
             measurement = "heavy_read_only"
             profiles = data["sizes"][0]["profile"]
             single_profile: dict = next((p for p in profiles if p["concurrency"] == 1))
             database_engine_version = data["postgres"]["server_version"]
-            benchmarks.extend(
-                [
-                    {
-                        **_benchmark_metafields(
-                            database,
-                            framework=framework_path,
-                            benchmark_id=":".join([framework, measurement]),
-                            extend_environment={
-                                "database_engine_version": database_engine_version
-                            },
-                        ),
-                        "config": {"concurrency": "single"},
-                        "score": single_profile["score"],
-                        "note": f"Latency: {single_profile['latency_avg_ms']} ms.",
-                    },
-                    {
-                        **_benchmark_metafields(
-                            database,
-                            framework=framework_path,
-                            benchmark_id=":".join([framework, measurement]),
-                            extend_environment={
-                                "database_engine_version": database_engine_version
-                            },
-                        ),
-                        "config": {"concurrency": "peak"},
-                        "score": data["score"],
-                        "note": f"Latency: {data['latency_avg_ms']} ms, concurrency: {data['peak_concurrency']}.",
-                    },
-                ]
-            )
+            return [
+                {
+                    **_benchmark_metafields(
+                        resource,
+                        framework=framework_path,
+                        benchmark_id=":".join([framework, measurement]),
+                        extend_environment={
+                            "database_engine_version": database_engine_version
+                        },
+                    ),
+                    "config": {"concurrency": "single"},
+                    "score": single_profile["score"],
+                    "note": f"Latency: {single_profile['latency_avg_ms']} ms.",
+                },
+                {
+                    **_benchmark_metafields(
+                        resource,
+                        framework=framework_path,
+                        benchmark_id=":".join([framework, measurement]),
+                        extend_environment={
+                            "database_engine_version": database_engine_version
+                        },
+                    ),
+                    "config": {"concurrency": "peak"},
+                    "score": data["score"],
+                    "note": f"Latency: {data['latency_avg_ms']} ms, concurrency: {data['peak_concurrency']}.",
+                },
+            ]
     except Exception as e:
-        _log_cannot_load_benchmarks(database, framework_path, e, True)
+        _log_cannot_load_benchmarks(resource, framework_path, e, True)
+    return []
 
-    return benchmarks
+
+def inspect_database_benchmarks(database: "Database") -> list[dict]:
+    return _pgbench_benchmark_scores(
+        database, framework_path_postfix="_postgres_dbaas_ro_durable"
+    )
 
 
 def _extract_manufacturer(name: str) -> str:

--- a/src/sc_crawler/table_bases.py
+++ b/src/sc_crawler/table_bases.py
@@ -1408,13 +1408,16 @@ class BenchmarkScoreFields(HasBenchmarkPKFK, HasVendorPKFK):
     @model_validator(mode="before")
     def update_config_to_hashable(cls, values):
         """Accept legacy ``server_id`` / ``database_id`` keys; hashably sort config."""
-        for key, rtype in (
-            ("server_id", ResourceType.SERVER),
-            ("database_id", ResourceType.DATABASE),
-        ):
-            if key in values:
-                values["resource_type"] = rtype
-                values["resource_id"] = values.pop(key)
+        has_server = "server_id" in values
+        has_database = "database_id" in values
+        if has_server and has_database:
+            raise ValueError("Provide only one of server_id or database_id.")
+        if has_server:
+            values["resource_type"] = ResourceType.SERVER
+            values["resource_id"] = values.pop("server_id")
+        elif has_database:
+            values["resource_type"] = ResourceType.DATABASE
+            values["resource_id"] = values.pop("database_id")
         values["config"] = HashableDict(sorted(values.get("config", {}).items()))
         return values
 
@@ -1475,10 +1478,12 @@ class BenchmarkScoreFields(HasBenchmarkPKFK, HasVendorPKFK):
 
     def to_response(self) -> dict:
         data = self.model_dump(exclude={"resource_type", "resource_id", "environment"})
-        data[f"{self.resource_type.value}_id"] = self.resource_id
+        resource_type = ResourceType(self.resource_type)
+        data[f"{resource_type.value}_id"] = self.resource_id
         if self.environment:
             for key, value in self.environment.items():
-                data[key] = value
+                if key not in data:
+                    data[key] = value
         return data
 
     @field_serializer("score_breakdown")

--- a/src/sc_crawler/table_bases.py
+++ b/src/sc_crawler/table_bases.py
@@ -13,6 +13,8 @@ from pydantic import (
     model_validator,
 )
 from rich.progress import Progress
+from sqlalchemy import and_, case
+from sqlalchemy.ext.hybrid import Comparator, hybrid_property
 from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import declared_attr, reconstructor
 from sqlmodel import JSON, Field, Session, SQLModel, select
@@ -37,6 +39,7 @@ from .table_fields import (
     HashableJSON,
     PriceTier,
     PriceUnit,
+    ResourceType,
     Status,
     StorageType,
     TrafficDirection,
@@ -1366,16 +1369,52 @@ class BenchmarkBase(MetaColumns, BenchmarkFields):
     pass
 
 
-class BenchmarkScoreFields(HasBenchmarkPKFK, HasServerPK, HasVendorPKFK):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
+class ResourceIdComparator(Comparator):
+    """Compile server_id/database_id to CASE + typed filter."""
+
+    def __init__(self, cls, resource_type, label):
+        self.cls = cls
+        self.resource_type = resource_type
+        self.label = label
+
+    def __clause_element__(self):
+        return case(
+            (self.cls.resource_type == self.resource_type, self.cls.resource_id),
+            else_=None,
+        ).label(self.label)
+
+    def operate(self, op, *other, **kwargs):
+        return and_(
+            self.cls.resource_type == self.resource_type,
+            op(self.cls.resource_id, *other, **kwargs),
+        )
+
+
+class BenchmarkScoreFields(HasBenchmarkPKFK, HasVendorPKFK):
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        ignored_types=(hybrid_property,),
+    )
+
+    resource_type: ResourceType = Field(
+        primary_key=True,
+        description="Kind of resource the score refers to.",
+    )
+    resource_id: str = Field(
+        primary_key=True,
+        description="Reference to the resource (see resource_type).",
+    )
 
     @model_validator(mode="before")
     def update_config_to_hashable(cls, values):
-        """We need a hashable column for the primary key.
-
-        Note that we also sort the keys, so that the resulting JSON
-        can be compared as text as well (as some database engines do).
-        """
+        """Accept legacy ``server_id`` / ``database_id`` keys; hashably sort config."""
+        for key, rtype in (
+            ("server_id", ResourceType.SERVER),
+            ("database_id", ResourceType.DATABASE),
+        ):
+            if key in values:
+                values["resource_type"] = rtype
+                values["resource_id"] = values.pop(key)
         values["config"] = HashableDict(sorted(values.get("config", {}).items()))
         return values
 
@@ -1391,9 +1430,13 @@ class BenchmarkScoreFields(HasBenchmarkPKFK, HasServerPK, HasVendorPKFK):
         default=None,
         description="The version of the benchmark tool used.",
     )
-    kernel_version: Optional[str] = Field(
+    environment: Optional[dict] = Field(
         default=None,
-        description="The kernel version of the server when the benchmark was run.",
+        sa_type=JSON,
+        description=(
+            "Extensible environment details "
+            "(e.g. kernel_version, database_engine_version)."
+        ),
     )
     score: float = Field(
         description="The resulting score of the benchmark.",
@@ -1411,6 +1454,29 @@ class BenchmarkScoreFields(HasBenchmarkPKFK, HasServerPK, HasVendorPKFK):
         default=None,
         description="Optional note, comment or context on the benchmark score.",
     )
+
+    @hybrid_property
+    def server_id(self) -> Optional[str]:
+        return self.resource_id if self.resource_type == ResourceType.SERVER else None
+
+    @server_id.inplace.comparator
+    @classmethod
+    def _server_id_comparator(cls):
+        return ResourceIdComparator(cls, ResourceType.SERVER, "server_id")
+
+    @hybrid_property
+    def database_id(self) -> Optional[str]:
+        return self.resource_id if self.resource_type == ResourceType.DATABASE else None
+
+    @database_id.inplace.comparator
+    @classmethod
+    def _database_id_comparator(cls):
+        return ResourceIdComparator(cls, ResourceType.DATABASE, "database_id")
+
+    def to_response(self) -> dict:
+        data = self.model_dump(exclude={"resource_type", "resource_id"})
+        data[f"{self.resource_type.value}_id"] = self.resource_id
+        return data
 
     @field_serializer("score_breakdown")
     def _serialize_score_breakdown(self, value: Optional[WorkloadScoreBreakdown]):
@@ -1434,71 +1500,4 @@ class BenchmarkScoreFields(HasBenchmarkPKFK, HasServerPK, HasVendorPKFK):
 
 
 class BenchmarkScoreBase(MetaColumns, BenchmarkScoreFields):
-    pass
-
-
-class DatabaseBenchmarkScoreFields(HasBenchmarkPKFK, HasDatabasePK, HasVendorPKFK):
-    model_config = ConfigDict(arbitrary_types_allowed=True)
-
-    @model_validator(mode="before")
-    def update_config_to_hashable(cls, values):
-        """We need a hashable column for the primary key.
-
-        Note that we also sort the keys, so that the resulting JSON
-        can be compared as text as well (as some database engines do).
-        """
-        values["config"] = HashableDict(sorted(values.get("config", {}).items()))
-        return values
-
-    # use HashableDict as it's a primary key that needs to be hashable, but
-    # fall back to dict to avoid PydanticInvalidForJsonSchema
-    config: HashableDict | dict = Field(
-        default={},
-        sa_type=HashableJSON,
-        primary_key=True,
-        description='Dictionary of config parameters of the specific benchmark, e.g. {"bandwidth": 4096}',
-    )
-    framework_version: Optional[str] = Field(
-        default=None,
-        description="The version of the benchmark tool used.",
-    )
-    score: float = Field(
-        description="The resulting score of the benchmark.",
-    )
-    score_breakdown: Optional[WorkloadScoreBreakdown] = Field(
-        default=None,
-        sa_type=JSON,
-        description=(
-            "Structured derivation of composite scores (e.g. workload profiles): "
-            "per-component raw values, references, normalized values, weights, and "
-            "coverage. Null for simple benchmark scores."
-        ),
-    )
-    note: Optional[str] = Field(
-        default=None,
-        description="Optional note, comment or context on the benchmark score.",
-    )
-
-    @field_serializer("score_breakdown")
-    def _serialize_score_breakdown(self, value: Optional[WorkloadScoreBreakdown]):
-        if value is None or isinstance(value, dict):
-            return value
-        if hasattr(value, "__json__"):
-            return value.__json__()
-        return value
-
-    @field_validator("score_breakdown", mode="before")
-    @classmethod
-    def _deserialize_score_breakdown(cls, value):
-        """Coerce a dict to WorkloadScoreBreakdown on construction."""
-        return WorkloadScoreBreakdown(**value) if isinstance(value, dict) else value
-
-    @reconstructor
-    def _reconstruct_score_breakdown(self):
-        """Re-coerce score_breakdown from the dict returned by a DB load."""
-        if isinstance(self.score_breakdown, dict):
-            self.score_breakdown = WorkloadScoreBreakdown(**self.score_breakdown)
-
-
-class DatabaseBenchmarkScoreBase(MetaColumns, DatabaseBenchmarkScoreFields):
     pass

--- a/src/sc_crawler/table_bases.py
+++ b/src/sc_crawler/table_bases.py
@@ -1474,8 +1474,11 @@ class BenchmarkScoreFields(HasBenchmarkPKFK, HasVendorPKFK):
         return ResourceIdComparator(cls, ResourceType.DATABASE, "database_id")
 
     def to_response(self) -> dict:
-        data = self.model_dump(exclude={"resource_type", "resource_id"})
+        data = self.model_dump(exclude={"resource_type", "resource_id", "environment"})
         data[f"{self.resource_type.value}_id"] = self.resource_id
+        if self.environment:
+            for key, value in self.environment.items():
+                data[key] = value
         return data
 
     @field_serializer("score_breakdown")

--- a/src/sc_crawler/table_bases.py
+++ b/src/sc_crawler/table_bases.py
@@ -1407,7 +1407,7 @@ class BenchmarkScoreFields(HasBenchmarkPKFK, HasVendorPKFK):
 
     @model_validator(mode="before")
     def update_config_to_hashable(cls, values):
-        """Accept legacy ``server_id`` / ``database_id`` keys; hashably sort config."""
+        """Accept ``server_id`` / ``database_id`` keys; hashably sort config."""
         has_server = "server_id" in values
         has_database = "database_id" in values
         if has_server and has_database:

--- a/src/sc_crawler/table_fields.py
+++ b/src/sc_crawler/table_fields.py
@@ -54,6 +54,15 @@ class Status(str, Enum):
     """Inactive resource that is not available anymore."""
 
 
+class ResourceType(str, Enum):
+    """Kind of resource a benchmark score refers to."""
+
+    SERVER = "server"
+    """Compute server / VM instance."""
+    DATABASE = "database"
+    """Managed database instance."""
+
+
 class Cpu(Json):
     """CPU details."""
 

--- a/src/sc_crawler/table_fields.py
+++ b/src/sc_crawler/table_fields.py
@@ -58,7 +58,7 @@ class ResourceType(str, Enum):
     """Kind of resource a benchmark score refers to."""
 
     SERVER = "server"
-    """Compute server / VM instance."""
+    """Compute server instance."""
     DATABASE = "database"
     """Managed database instance."""
 

--- a/src/sc_crawler/tables.py
+++ b/src/sc_crawler/tables.py
@@ -48,6 +48,7 @@ from .table_fields import (
     CpuAllocation,  # noqa: F401 imported for mkdocstrings
     CpuArchitecture,  # noqa: F401 imported for mkdocstrings
     PriceUnit,  # noqa: F401 imported for mkdocstrings
+    ResourceType,
     Status,
     StorageType,  # noqa: F401 imported for mkdocstrings
     TrafficDirection,  # noqa: F401 imported for mkdocstrings
@@ -326,7 +327,7 @@ class Vendor(VendorBase, table=True):
         self.set_table_rows_inactive(
             BenchmarkScore,
             BenchmarkScore.vendor_id == self.vendor_id,
-            BenchmarkScore.resource_type == "SERVER",
+            BenchmarkScore.resource_type == ResourceType.SERVER,
         )
         insert_items(BenchmarkScore, benchmarks, self)
         self.progress_tracker.start_task(
@@ -418,7 +419,7 @@ class Vendor(VendorBase, table=True):
         self.set_table_rows_inactive(
             BenchmarkScore,
             BenchmarkScore.vendor_id == self.vendor_id,
-            BenchmarkScore.resource_type == "DATABASE",
+            BenchmarkScore.resource_type == ResourceType.DATABASE,
         )
         insert_items(BenchmarkScore, benchmarks, self)
 

--- a/src/sc_crawler/tables.py
+++ b/src/sc_crawler/tables.py
@@ -15,6 +15,7 @@ from .description_ingestor import (
 )
 from .insert import insert_items
 from .inspector import (
+    inspect_database_benchmarks,
     inspect_server_benchmarks,
     inspect_update_server_dict,
     inspector_data_path,
@@ -316,14 +317,16 @@ class Vendor(VendorBase, table=True):
         insert_items(Server, servers, self)
         benchmarks = []
         self.progress_tracker.start_task(
-            name="Searching for benchmark(s)", total=len(self.servers)
+            name="Searching for server benchmark(s)", total=len(self.servers)
         )
         for server in self.servers:
             benchmarks += inspect_server_benchmarks(server)
             self.progress_tracker.advance_task()
         self.progress_tracker.hide_task()
         self.set_table_rows_inactive(
-            BenchmarkScore, BenchmarkScore.vendor_id == self.vendor_id
+            BenchmarkScore,
+            BenchmarkScore.vendor_id == self.vendor_id,
+            BenchmarkScore.resource_type == "SERVER",
         )
         insert_items(BenchmarkScore, benchmarks, self)
         self.progress_tracker.start_task(
@@ -394,12 +397,34 @@ class Vendor(VendorBase, table=True):
 
     @log_start_end
     def inventory_databases(self):
-        """Get the vendor's all managed database SKUs."""
-        self._inventory(Database, self._get_methods().inventory_databases)
+        """Get the vendor's all managed database types."""
+        self.set_table_rows_inactive(Database)
+        databases = self._get_methods().inventory_databases(self)
+        # show progress bar while downloading
+        self.progress_tracker.start_task(
+            name="Downloading sc-inspector-data", total=None
+        )
+        inspector_data_path()
+        self.progress_tracker.hide_task()
+        insert_items(Database, databases, self)
+        benchmarks = []
+        self.progress_tracker.start_task(
+            name="Searching for database benchmark(s)", total=len(self.databases)
+        )
+        for database in self.databases:
+            benchmarks += inspect_database_benchmarks(database)
+            self.progress_tracker.advance_task()
+        self.progress_tracker.hide_task()
+        self.set_table_rows_inactive(
+            BenchmarkScore,
+            BenchmarkScore.vendor_id == self.vendor_id,
+            BenchmarkScore.resource_type == "DATABASE",
+        )
+        insert_items(BenchmarkScore, benchmarks, self)
 
     @log_start_end
     def inventory_database_prices(self):
-        """Get the current prices of all managed database SKUs."""
+        """Get the current prices of all managed database types."""
         self._inventory_price_rounding(
             DatabasePrice,
             self._get_methods().inventory_database_prices,

--- a/src/sc_crawler/tables.py
+++ b/src/sc_crawler/tables.py
@@ -26,7 +26,6 @@ from .table_bases import (
     ComplianceFrameworkBase,
     CountryBase,
     DatabaseBase,
-    DatabaseBenchmarkScoreBase,
     DatabasePriceBase,
     DatabaseStorageBase,
     DatabaseStoragePriceBase,
@@ -124,9 +123,6 @@ class Vendor(VendorBase, table=True):
         back_populates="vendor", sa_relationship_kwargs={"viewonly": True}
     )
     benchmark_scores: List["BenchmarkScore"] = Relationship(
-        back_populates="vendor", sa_relationship_kwargs={"viewonly": True}
-    )
-    database_benchmark_scores: List["DatabaseBenchmarkScore"] = Relationship(
         back_populates="vendor", sa_relationship_kwargs={"viewonly": True}
     )
 
@@ -510,7 +506,15 @@ class Server(ServerBase, table=True):
         back_populates="server", sa_relationship_kwargs={"viewonly": True}
     )
     benchmark_scores: List["BenchmarkScore"] = Relationship(
-        back_populates="server", sa_relationship_kwargs={"viewonly": True}
+        back_populates="server",
+        sa_relationship_kwargs={
+            "viewonly": True,
+            "primaryjoin": (
+                "and_(Server.server_id == foreign(BenchmarkScore.resource_id), "
+                "Server.vendor_id == foreign(BenchmarkScore.vendor_id), "
+                "BenchmarkScore.resource_type == 'SERVER')"
+            ),
+        },
     )
 
 
@@ -619,8 +623,16 @@ class Database(DatabaseBase, table=True):
     prices: List["DatabasePrice"] = Relationship(
         back_populates="database", sa_relationship_kwargs={"viewonly": True}
     )
-    database_benchmark_scores: List["DatabaseBenchmarkScore"] = Relationship(
-        back_populates="database", sa_relationship_kwargs={"viewonly": True}
+    benchmark_scores: List["BenchmarkScore"] = Relationship(
+        back_populates="database",
+        sa_relationship_kwargs={
+            "viewonly": True,
+            "primaryjoin": (
+                "and_(Database.database_id == foreign(BenchmarkScore.resource_id), "
+                "Database.vendor_id == foreign(BenchmarkScore.vendor_id), "
+                "BenchmarkScore.resource_type == 'DATABASE')"
+            ),
+        },
     )
 
 
@@ -758,55 +770,37 @@ class Benchmark(BenchmarkBase, table=True):
     benchmark_scores: List["BenchmarkScore"] = Relationship(
         back_populates="benchmark", sa_relationship_kwargs={"viewonly": True}
     )
-    database_benchmark_scores: List["DatabaseBenchmarkScore"] = Relationship(
-        back_populates="benchmark", sa_relationship_kwargs={"viewonly": True}
-    )
 
 
 class BenchmarkScore(BenchmarkScoreBase, table=True):
-    """Results of running Benchmark scenarios on Servers."""
+    """Results of running Benchmark scenarios on Servers or managed Databases."""
 
-    __table_args__ = (
-        ForeignKeyConstraint(
-            ["vendor_id", "server_id"],
-            ["server.vendor_id", "server.server_id"],
-        ),
-    )
     vendor: Vendor = Relationship(back_populates="benchmark_scores")
-    server: Server = Relationship(
+    server: Optional[Server] = Relationship(
         back_populates="benchmark_scores",
         sa_relationship_kwargs={
             "primaryjoin": (
-                "and_(Server.server_id == foreign(BenchmarkScore.server_id), "
-                "Server.vendor_id == foreign(BenchmarkScore.vendor_id))"
+                "and_(Server.server_id == foreign(BenchmarkScore.resource_id), "
+                "Server.vendor_id == foreign(BenchmarkScore.vendor_id), "
+                "BenchmarkScore.resource_type == 'SERVER')"
             ),
-            "overlaps": "vendor",
+            "overlaps": "vendor,database",
+            "viewonly": True,
+        },
+    )
+    database: Optional[Database] = Relationship(
+        back_populates="benchmark_scores",
+        sa_relationship_kwargs={
+            "primaryjoin": (
+                "and_(Database.database_id == foreign(BenchmarkScore.resource_id), "
+                "Database.vendor_id == foreign(BenchmarkScore.vendor_id), "
+                "BenchmarkScore.resource_type == 'DATABASE')"
+            ),
+            "overlaps": "vendor,server",
+            "viewonly": True,
         },
     )
     benchmark: Benchmark = Relationship(back_populates="benchmark_scores")
-
-
-class DatabaseBenchmarkScore(DatabaseBenchmarkScoreBase, table=True):
-    """Results of running Benchmark scenarios on managed Databases."""
-
-    __table_args__ = (
-        ForeignKeyConstraint(
-            ["vendor_id", "database_id"],
-            ["database.vendor_id", "database.database_id"],
-        ),
-    )
-    vendor: Vendor = Relationship(back_populates="database_benchmark_scores")
-    database: Database = Relationship(
-        back_populates="database_benchmark_scores",
-        sa_relationship_kwargs={
-            "primaryjoin": (
-                "and_(Database.database_id == foreign(DatabaseBenchmarkScore.database_id), "
-                "Database.vendor_id == foreign(DatabaseBenchmarkScore.vendor_id))"
-            ),
-            "overlaps": "vendor",
-        },
-    )
-    benchmark: Benchmark = Relationship(back_populates="database_benchmark_scores")
 
 
 Country.model_rebuild()

--- a/src/sc_crawler/tables_scd.py
+++ b/src/sc_crawler/tables_scd.py
@@ -11,7 +11,6 @@ from .table_bases import (
     ComplianceFrameworkBase,
     CountryBase,
     DatabaseBase,
-    DatabaseBenchmarkScoreBase,
     DatabasePriceBase,
     DatabaseStorageBase,
     DatabaseStoragePriceBase,
@@ -215,19 +214,6 @@ class BenchmarkScd(Scd, BenchmarkBase, table=True):
 
 class BenchmarkScoreScd(Scd, BenchmarkScoreBase, table=True):
     """SCD version of .tables.BenchmarkScore."""
-
-    benchmark_id: str = Field(
-        primary_key=True,
-        description="Reference to the Benchmark.",
-    )
-    vendor_id: str = Field(
-        primary_key=True,
-        description="Reference to the Vendor.",
-    )
-
-
-class DatabaseBenchmarkScoreScd(Scd, DatabaseBenchmarkScoreBase, table=True):
-    """SCD version of .tables.DatabaseBenchmarkScore."""
 
     benchmark_id: str = Field(
         primary_key=True,

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -1537,9 +1537,15 @@ def inventory_database_prices(vendor):
                     vcpu_sku = compute_index.get(
                         (region.api_reference, price_family, "vcpu", availability)
                     )
+                    # N4/C4A billing has Enterprise N4 vCPU meters, but RAM uses the
+                    # generic PostgreSQL RAM meters (no "Enterprise N4 RAM" SKU).
                     ram_sku = compute_index.get(
                         (region.api_reference, price_family, "ram", availability)
                     )
+                    if ram_sku is None and price_family == "enterprise_n4":
+                        ram_sku = compute_index.get(
+                            (region.api_reference, "enterprise", "ram", availability)
+                        )
                     if vcpu_sku is not None and ram_sku is not None:
                         vcpu_hourly = _sku_unit_price(vcpu_sku)
                         ram_hourly = _sku_unit_price(ram_sku)

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -910,6 +910,78 @@ def test_gcp_database_prices_use_region_name_not_numeric_id():
     assert prices[0]["ha_strategy"] == DatabaseHaStrategy.NONE
 
 
+def test_gcp_n4_family_prices_fall_back_to_enterprise_ram():
+    # Enterprise N4 vCPU + generic PostgreSQL RAM (no Enterprise N4 RAM SKU).
+    # 0.0542 * 4 + 0.0091 * 32 = 0.508
+    skus = [
+        _gcp_pg_sku(
+            "Cloud SQL for Postgres: Zonal - Enterprise N4 vCPU in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=54_200_000,
+        ),
+        _gcp_pg_sku(
+            "Cloud SQL for PostgreSQL: Zonal - RAM in Americas",
+            regions=["us-central1"],
+            units=0,
+            nanos=9_100_000,
+        ),
+        _gcp_pg_sku(
+            "Cloud SQL for Postgres: Regional - Enterprise N4 vCPU in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=108_400_000,
+        ),
+        _gcp_pg_sku(
+            "Cloud SQL for PostgreSQL: Regional - RAM in Americas",
+            regions=["us-central1"],
+            units=0,
+            nanos=18_200_000,
+        ),
+    ]
+    vendor = Mock(vendor_id="gcp")
+    vendor.regions = [Mock(region_id="1", api_reference="us-central1")]
+    vendor.progress_tracker = Mock(
+        start_task=Mock(), advance_task=Mock(), hide_task=Mock()
+    )
+    tiers = [
+        {
+            "tier": "db-c4a-highmem-4",
+            "RAM": str(32 * 1024**3),
+            "region": ["us-central1"],
+        },
+        {
+            "tier": "db-perf-optimized-N-4",
+            "RAM": str(32 * 1024**3),
+            "region": ["us-central1"],
+        },
+        {
+            "tier": "db-memory-optimized-N-4",
+            "RAM": str(32 * 1024**3),
+            "region": ["us-central1"],
+        },
+    ]
+    with (
+        patch("sc_crawler.vendors._gcp._cloud_sql_skus", return_value=skus),
+        patch(
+            "sc_crawler.vendors._gcp._pg_sqladmin_metadata",
+            return_value={"tiers": tiers},
+        ),
+    ):
+        prices = inventory_database_prices(vendor)
+    by_id_ha = {(row["database_id"], row["ha"]): row for row in prices}
+    for database_id in (
+        "db-c4a-highmem-4",
+        "db-perf-optimized-N-4",
+        "db-memory-optimized-N-4",
+    ):
+        zonal = by_id_ha[(database_id, DatabaseHaLevel.NONE)]
+        regional = by_id_ha[(database_id, DatabaseHaLevel.MULTI_ZONE)]
+        assert abs(zonal["price"] - 0.508) < 0.001
+        assert abs(regional["price"] - 1.016) < 0.001
+        assert regional["ha_strategy"] == DatabaseHaStrategy.PASSIVE_STANDBY
+
+
 def test_gcp_database_prices_emit_regional_ha_rows():
     skus = [
         _gcp_pg_sku(

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -108,7 +108,7 @@ def test_database_base_round_trip():
     assert item.api_reference_object is None
 
 
-def test_database_benchmark_score_via_legacy_database_id_key():
+def test_database_benchmark_score_via_database_id_key():
     item = BenchmarkScoreBase.model_validate(
         {
             "vendor_id": "gcp",

--- a/tests/test_insert.py
+++ b/tests/test_insert.py
@@ -2,7 +2,6 @@ from sc_crawler.insert import _dedupe_items, _primary_key_tuple
 from sc_crawler.table_bases import (
     BenchmarkScoreBase,
     DatabaseBase,
-    DatabaseBenchmarkScoreBase,
     DatabasePriceBase,
 )
 from sc_crawler.table_fields import (
@@ -13,6 +12,7 @@ from sc_crawler.table_fields import (
     DatabaseSecurityFeature,
     DatabaseWireProtocol,
     PriceUnit,
+    ResourceType,
     Status,
 )
 
@@ -20,7 +20,7 @@ from sc_crawler.table_fields import (
 def test_primary_key_tuple_normalizes_json_config_key_order():
     item_a = {"config": {"size": 1.0, "operation": "rd"}}
     item_b = {"config": {"operation": "rd", "size": 1.0}}
-    keys = ("vendor_id", "server_id", "benchmark_id", "config")
+    keys = ("vendor_id", "resource_type", "resource_id", "benchmark_id", "config")
 
     assert _primary_key_tuple(item_a, list(keys)) == _primary_key_tuple(
         item_b, list(keys)
@@ -33,7 +33,7 @@ def test_dedupe_items_collapses_duplicate_benchmark_scores():
         "server_id": "t3.micro",
         "benchmark_id": "bw_mem",
         "framework_version": None,
-        "kernel_version": None,
+        "environment": None,
         "score": 1.0,
         "score_breakdown": None,
         "note": None,
@@ -47,11 +47,13 @@ def test_dedupe_items_collapses_duplicate_benchmark_scores():
     validated = [BenchmarkScoreBase.model_validate(item).model_dump() for item in items]
     deduped = _dedupe_items(
         validated,
-        ["vendor_id", "server_id", "benchmark_id", "config"],
+        ["vendor_id", "resource_type", "resource_id", "benchmark_id", "config"],
     )
 
     assert len(deduped) == 1
     assert deduped[0]["score"] == 2.0
+    assert deduped[0]["resource_type"] == ResourceType.SERVER
+    assert deduped[0]["resource_id"] == "t3.micro"
 
 
 def test_dedupe_items_collapses_duplicate_database_prices():
@@ -106,8 +108,8 @@ def test_database_base_round_trip():
     assert item.api_reference_object is None
 
 
-def test_database_benchmark_score_base_round_trip():
-    item = DatabaseBenchmarkScoreBase.model_validate(
+def test_database_benchmark_score_via_legacy_database_id_key():
+    item = BenchmarkScoreBase.model_validate(
         {
             "vendor_id": "gcp",
             "database_id": "db-n1-standard-4",
@@ -117,6 +119,8 @@ def test_database_benchmark_score_base_round_trip():
             "status": Status.ACTIVE,
         }
     )
+    assert item.resource_type == ResourceType.DATABASE
+    assert item.resource_id == "db-n1-standard-4"
     assert item.database_id == "db-n1-standard-4"
     assert item.config == {"clients": 4, "scale": 100}
     assert item.score == 1234.5

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -483,10 +483,23 @@ def test_benchmark_score_legacy_key_translation_and_hybrids():
     assert server_item.database_id is None
 
     response = server_item.to_response()
-    assert response["server_id"] == "m5.large"
+    assert response == {
+        "vendor_id": "aws",
+        "benchmark_id": "bogomips",
+        "config": {},
+        "framework_version": None,
+        "score": 1.0,
+        "score_breakdown": None,
+        "note": None,
+        "status": server_item.status,
+        "observed_at": server_item.observed_at,
+        "server_id": "m5.large",
+        "kernel_version": "6.8.0",
+    }
     assert "database_id" not in response
     assert "resource_type" not in response
     assert "resource_id" not in response
+    assert "environment" not in response
 
     db_item = BenchmarkScoreBase.model_validate(
         {
@@ -504,9 +517,25 @@ def test_benchmark_score_legacy_key_translation_and_hybrids():
 
     db_response = db_item.to_response()
     assert db_response["database_id"] == "db.m5.large"
+    assert db_response["database_engine_version"] == "16.3"
     assert "server_id" not in db_response
     assert "resource_type" not in db_response
     assert "resource_id" not in db_response
+    assert "environment" not in db_response
+
+    bare = BenchmarkScoreBase.model_validate(
+        {
+            "vendor_id": "aws",
+            "server_id": "t3.micro",
+            "benchmark_id": "bogomips",
+            "config": {},
+            "score": 3.0,
+        }
+    )
+    bare_response = bare.to_response()
+    assert bare_response["server_id"] == "t3.micro"
+    assert "environment" not in bare_response
+    assert "kernel_version" not in bare_response
 
     filter_sql = str(select(BenchmarkScore).where(BenchmarkScore.server_id == "x"))
     assert "resource_type" in filter_sql

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -461,7 +461,7 @@ def test_validate_items_keeps_datetime_objects():
     assert validated["observed_at"] == observed_at
 
 
-def test_benchmark_score_legacy_key_translation_and_hybrids():
+def test_benchmark_score_key_translation_and_hybrids():
     from sqlmodel import select
 
     from sc_crawler.table_bases import BenchmarkScoreBase
@@ -559,7 +559,7 @@ def test_benchmark_score_legacy_key_translation_and_hybrids():
     assert "AS database_id" in select_sql
 
 
-def test_benchmark_score_rejects_both_legacy_ids():
+def test_benchmark_score_rejects_both_ids():
     from pydantic import ValidationError
 
     from sc_crawler.table_bases import BenchmarkScoreBase

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -537,6 +537,19 @@ def test_benchmark_score_legacy_key_translation_and_hybrids():
     assert "environment" not in bare_response
     assert "kernel_version" not in bare_response
 
+    constructed = BenchmarkScoreBase.model_construct(
+        vendor_id="aws",
+        resource_type="server",
+        resource_id="m5.large",
+        benchmark_id="bogomips",
+        config={},
+        score=4.0,
+        environment={"server_id": "env-should-not-win", "kernel_version": "6.1.0"},
+    )
+    constructed_response = constructed.to_response()
+    assert constructed_response["server_id"] == "m5.large"
+    assert constructed_response["kernel_version"] == "6.1.0"
+
     filter_sql = str(select(BenchmarkScore).where(BenchmarkScore.server_id == "x"))
     assert "resource_type" in filter_sql
     assert "resource_id" in filter_sql
@@ -544,3 +557,25 @@ def test_benchmark_score_legacy_key_translation_and_hybrids():
     select_sql = str(select(BenchmarkScore.server_id, BenchmarkScore.database_id))
     assert "AS server_id" in select_sql
     assert "AS database_id" in select_sql
+
+
+def test_benchmark_score_rejects_both_legacy_ids():
+    from pydantic import ValidationError
+
+    from sc_crawler.table_bases import BenchmarkScoreBase
+
+    try:
+        BenchmarkScoreBase.model_validate(
+            {
+                "vendor_id": "aws",
+                "server_id": "m5.large",
+                "database_id": "db.m5.large",
+                "benchmark_id": "bogomips",
+                "config": {},
+                "score": 1.0,
+            }
+        )
+    except ValidationError as e:
+        assert "only one of server_id or database_id" in str(e)
+    else:
+        raise AssertionError("expected ValidationError")

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -17,7 +17,6 @@ from sc_crawler.tables import (
     BenchmarkScore,
     Country,
     Database,
-    DatabaseBenchmarkScore,
     DatabasePrice,
     DatabaseStoragePrice,
     StoragePrice,
@@ -37,21 +36,21 @@ def test_scmodels_have_base():
         assert not hasattr(schema, "__table__")
 
 
-def test_database_benchmark_score_primary_keys_mirror_benchmark_score():
+def test_benchmark_score_primary_keys_include_resource_discriminator():
     assert BenchmarkScore.get_columns()["primary_keys"] == [
         "vendor_id",
-        "server_id",
         "benchmark_id",
+        "resource_type",
+        "resource_id",
         "config",
     ]
-    assert DatabaseBenchmarkScore.get_columns()["primary_keys"] == [
-        "vendor_id",
-        "database_id",
-        "benchmark_id",
-        "config",
-    ]
-    assert "server_id" not in DatabaseBenchmarkScore.get_columns()["all"]
-    assert DatabaseBenchmarkScore.get_table_name() == "database_benchmark_score"
+    cols = BenchmarkScore.get_columns()["all"]
+    assert "server_id" not in cols
+    assert "database_id" not in cols
+    assert "kernel_version" not in cols
+    assert "environment" in cols
+    assert BenchmarkScore.get_table_name() == "benchmark_score"
+    assert "database_benchmark_score" not in [t.get_table_name() for t in tables]
 
 
 def test_database_price_primary_keys_match_storage_price_shape():
@@ -460,3 +459,59 @@ def test_validate_items_keeps_datetime_objects():
 
     assert isinstance(validated["observed_at"], datetime)
     assert validated["observed_at"] == observed_at
+
+
+def test_benchmark_score_legacy_key_translation_and_hybrids():
+    from sqlmodel import select
+
+    from sc_crawler.table_bases import BenchmarkScoreBase
+    from sc_crawler.table_fields import ResourceType
+
+    server_item = BenchmarkScoreBase.model_validate(
+        {
+            "vendor_id": "aws",
+            "server_id": "m5.large",
+            "benchmark_id": "bogomips",
+            "config": {},
+            "score": 1.0,
+            "environment": {"kernel_version": "6.8.0"},
+        }
+    )
+    assert server_item.resource_type == ResourceType.SERVER
+    assert server_item.resource_id == "m5.large"
+    assert server_item.server_id == "m5.large"
+    assert server_item.database_id is None
+
+    response = server_item.to_response()
+    assert response["server_id"] == "m5.large"
+    assert "database_id" not in response
+    assert "resource_type" not in response
+    assert "resource_id" not in response
+
+    db_item = BenchmarkScoreBase.model_validate(
+        {
+            "vendor_id": "aws",
+            "database_id": "db.m5.large",
+            "benchmark_id": "pgbench",
+            "config": {},
+            "score": 2.0,
+            "environment": {"database_engine_version": "16.3"},
+        }
+    )
+    assert db_item.resource_type == ResourceType.DATABASE
+    assert db_item.server_id is None
+    assert db_item.database_id == "db.m5.large"
+
+    db_response = db_item.to_response()
+    assert db_response["database_id"] == "db.m5.large"
+    assert "server_id" not in db_response
+    assert "resource_type" not in db_response
+    assert "resource_id" not in db_response
+
+    filter_sql = str(select(BenchmarkScore).where(BenchmarkScore.server_id == "x"))
+    assert "resource_type" in filter_sql
+    assert "resource_id" in filter_sql
+
+    select_sql = str(select(BenchmarkScore.server_id, BenchmarkScore.database_id))
+    assert "AS server_id" in select_sql
+    assert "AS database_id" in select_sql


### PR DESCRIPTION
# Overview

- Reshape `benchmark_score`: add `resource_type` discriminator and `resource_id`
  (replaces `server_id`); replace `kernel_version` with an extensible
  `environment` JSON column (e.g. `kernel_version`, `database_engine_version`)
- Keep legacy `server_id` / `database_id` query and insert keys via hybrid
  properties and input-dict translation
- Drop empty `database_benchmark_score`; database scores use `benchmark_score`
  with `resource_type=DATABASE`
- Collect DBaaS benchmark scores (`pgbench_postgres_dbaas_ro_durable`)

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [x] Branch is based on and up-to-date with `main`
- [x] PR has a clear title and/or brief description
- [x] PR builders passed
- [x] No red flags from coderabbit.ai
- [x] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [x] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [x] Package version bumped in `pyproject.toml`
- [x] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [x] Alembic migrations are provided for database schema changes
    - [x] Tested on SQLite
    - [x] Tested on PostgreSQL
- [x] `sc-crawler pull` was tested on all vendors and records
- [x] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [x] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added database benchmark collection using `pgbench`.
  * Unified server and database benchmark results in a shared scoring system.
  * Added extensible environment metadata for benchmark results.
  * Legacy server and database identifiers remain supported.
  * Updated database inventory processing to include benchmark results.

* **Bug Fixes**
  * Improved benchmark metadata handling and response serialization.
  * Added fallback pricing for supported Cloud SQL PostgreSQL tiers.

* **Documentation**
  * Added the v0.9.0 changelog entry.
  * Updated the package version to 0.9.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->