### PR TITLE
ingest raw pgbench metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 ‼ Breaking changes:
 
+- `benchmark_score` responses expose `environment` as an object;
+  `kernel_version` / `database_engine_version` are no longer top-level fields.
 - Reshape `pgbench:heavy_read_only` ingest: `concurrency` is now an integer
   (one raw score per profile point). Old string configs `"single"` / `"peak"`
   move to config-less `pgbench:heavy_read_only:single` and
   `pgbench:heavy_read_only:peak`.
+
+New:
+
+- pgbench scores record `latency_avg_ms` (plus `peak_concurrency` on the peak
+  row) in `environment`.
 
 ## v0.9.0 (August 10, 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v0.9.1 (August 14, 2026)
+
+‼ Breaking changes:
+
+- Reshape `pgbench:heavy_read_only` ingest: `concurrency` is now an integer
+  (one raw score per profile point). Old string configs `"single"` / `"peak"`
+  move to config-less `pgbench:heavy_read_only:single` and
+  `pgbench:heavy_read_only:peak`.
+
 ## v0.9.0 (August 10, 2026)
 
 ‼ Breaking changes:

--- a/src/sc_crawler/__init__.py
+++ b/src/sc_crawler/__init__.py
@@ -1,4 +1,4 @@
 """Spare Cores crawler: collect and standardize cloud server offerings data."""
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 __version_info__ = tuple(int(x) for x in __version__.split(".")[:3])

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -851,7 +851,6 @@ def _pgbench_benchmark_scores(
             data = json.load(fp)
             measurement = "heavy_read_only"
             profiles = data["sizes"][0]["profile"]
-            single_profile: dict = next((p for p in profiles if p["concurrency"] == 1))
             database_engine_version = data["postgres"]["server_version"].split()[0]
             benchmark_metafields = _benchmark_metafields(
                 resource,
@@ -859,20 +858,36 @@ def _pgbench_benchmark_scores(
                 benchmark_id=":".join([framework, measurement]),
                 extend_environment={"database_engine_version": database_engine_version},
             )
-            return [
+            scores = [
                 {
                     **benchmark_metafields,
-                    "config": {"concurrency": "single"},
+                    "config": {"concurrency": int(profile["concurrency"])},
+                    "score": profile["score"],
+                    "note": f"Latency: {profile['latency_avg_ms']} ms.",
+                }
+                for profile in profiles
+            ]
+            single_profile = next((p for p in profiles if p["concurrency"] == 1))
+            scores.append(
+                {
+                    **benchmark_metafields,
+                    "benchmark_id": ":".join([framework, measurement, "single"]),
                     "score": single_profile["score"],
                     "note": f"Latency: {single_profile['latency_avg_ms']} ms.",
-                },
+                }
+            )
+            scores.append(
                 {
                     **benchmark_metafields,
-                    "config": {"concurrency": "peak"},
+                    "benchmark_id": ":".join([framework, measurement, "peak"]),
                     "score": data["score"],
-                    "note": f"Latency: {data['latency_avg_ms']} ms, concurrency: {data['peak_concurrency']}.",
-                },
-            ]
+                    "note": (
+                        f"Latency: {data['latency_avg_ms']} ms, "
+                        f"concurrency: {data['peak_concurrency']}."
+                    ),
+                }
+            )
+            return scores
     except Exception as e:
         _log_cannot_load_benchmarks(resource, framework_path, e, True)
     return []

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -872,16 +872,12 @@ def _pgbench_benchmark_scores(
                 }
                 for profile in profiles
             ]
-            single_profile = next(
-                (p for p in profiles if p["concurrency"] == 1), None
-            )
+            single_profile = next((p for p in profiles if p["concurrency"] == 1), None)
             if single_profile is not None:
                 scores.append(
                     {
                         **benchmark_metafields,
-                        "benchmark_id": ":".join(
-                            [framework, measurement, "single"]
-                        ),
+                        "benchmark_id": ":".join([framework, measurement, "single"]),
                         "score": single_profile["score"],
                         "environment": {
                             **base_environment,

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -858,29 +858,48 @@ def _pgbench_benchmark_scores(
                 benchmark_id=":".join([framework, measurement]),
                 extend_environment={"database_engine_version": database_engine_version},
             )
+            base_environment = benchmark_metafields.get("environment", {})
             scores = [
                 {
                     **benchmark_metafields,
                     "config": {"concurrency": int(profile["concurrency"])},
                     "score": profile["score"],
+                    "environment": {
+                        **base_environment,
+                        "latency_avg_ms": profile["latency_avg_ms"],
+                    },
                     "note": f"Latency: {profile['latency_avg_ms']} ms.",
                 }
                 for profile in profiles
             ]
-            single_profile = next((p for p in profiles if p["concurrency"] == 1))
-            scores.append(
-                {
-                    **benchmark_metafields,
-                    "benchmark_id": ":".join([framework, measurement, "single"]),
-                    "score": single_profile["score"],
-                    "note": f"Latency: {single_profile['latency_avg_ms']} ms.",
-                }
+            single_profile = next(
+                (p for p in profiles if p["concurrency"] == 1), None
             )
+            if single_profile is not None:
+                scores.append(
+                    {
+                        **benchmark_metafields,
+                        "benchmark_id": ":".join(
+                            [framework, measurement, "single"]
+                        ),
+                        "score": single_profile["score"],
+                        "environment": {
+                            **base_environment,
+                            "latency_avg_ms": single_profile["latency_avg_ms"],
+                        },
+                        "note": f"Latency: {single_profile['latency_avg_ms']} ms.",
+                    }
+                )
             scores.append(
                 {
                     **benchmark_metafields,
                     "benchmark_id": ":".join([framework, measurement, "peak"]),
                     "score": data["score"],
+                    "environment": {
+                        **base_environment,
+                        "latency_avg_ms": data["latency_avg_ms"],
+                        "peak_concurrency": data["peak_concurrency"],
+                    },
                     "note": (
                         f"Latency: {data['latency_avg_ms']} ms, "
                         f"concurrency: {data['peak_concurrency']}."

--- a/src/sc_crawler/lookup.py
+++ b/src/sc_crawler/lookup.py
@@ -143,6 +143,15 @@ _BENCHMARK_SINGLE_THREAD_NOTE = (
     "do not increase with vCPU count beyond one core."
 )
 
+_BENCHMARK_SINGLE_SESSION_NOTE = (
+    "This benchmark is measured with a single client session, so throughput "
+    "does not necessarily grow with vCPU count. On the other hand, it is "
+    "not a purely single-threaded metric, as the server may still engage "
+    "multiple cores (e.g. parallel request handlers and background processes). "
+    "Use it as a per-session efficiency baseline rather than a measure of "
+    "instance capacity."
+)
+
 
 def _benchmark_throughput_latency_note(throughput_benchmark_id: str) -> str:
     return (
@@ -729,23 +738,67 @@ benchmarks: List[Benchmark] = [
         name="PostgreSQL heavy read-only throughput",
         category="Database",
         description=(
-            "Measures peak PostgreSQL throughput with a remote pgbench client against "
+            "Measures PostgreSQL throughput with a remote pgbench client against "
             "a custom, cache-resident, read-only transaction (joins, aggregates, "
             "full-text search, arrays, regex, TOAST) that fits in shared_buffers, so "
             "the score reflects engine CPU and memory behavior rather than disk or "
             "network. Server and client run in the same availability zone. Servers "
             "use pgtune-style host GUCs, while DBaaS keep the vendor-managed config. "
-            "Headline score is the maximum TPM over a fixed concurrency profile of 1, "
-            "vCPUS/2, vCPUS, and 2*vCPUs. This is a synthetic proxy for relative "
-            "RDBMS performance across server types, not a prediction of any specific "
-            "application's throughput."
+            "Each score is TPM at a given client concurrency; the typical profile is "
+            "1, vCPUs/2, vCPUs, and 2*vCPUs (additional points may be present). This "
+            "is a synthetic proxy for relative RDBMS performance across server types, "
+            "not a prediction of any specific application's throughput."
         ),
         framework="pgbench",
         measurement="heavy_read_only",
         source={"kind": "measured"},
         config_fields={
-            "concurrency": "Parallel client query count. Single means sequential connection, peak refers to the concurrency profile setting yielding maximum measured TPM."
+            "concurrency": (
+                "Parallel client query count (integer). Typical profile: 1, "
+                "vCPUs/2, vCPUs, and 2*vCPUs (may include additional points)."
+            )
         },
+        unit="Transactions per minute (TPM)",
+    ),
+    Benchmark(
+        benchmark_id="pgbench:heavy_read_only:single",
+        name="PostgreSQL heavy read-only baseline (single connection)",
+        category="Database",
+        description=(
+            "Baseline PostgreSQL throughput with a single remote pgbench client "
+            "connection against a custom, cache-resident, read-only transaction "
+            "(joins, aggregates, full-text search, arrays, regex, TOAST) that fits "
+            "in shared_buffers. Server and client run in the same availability zone. "
+            "Servers use pgtune-style host GUCs, while DBaaS keep the vendor-managed "
+            "config. Useful for comparing per-session engine and CPU efficiency "
+            "across server types and sizes, because the score does not necessarily scale with "
+            "extra vCPUs the way peak throughput does. This is a synthetic proxy for "
+            "relative RDBMS performance, not a prediction of any specific "
+            "application's throughput."
+        ),
+        framework="pgbench",
+        measurement="heavy_read_only:single",
+        source={"kind": "measured"},
+        unit="Transactions per minute (TPM)",
+        note=_BENCHMARK_SINGLE_SESSION_NOTE,
+    ),
+    Benchmark(
+        benchmark_id="pgbench:heavy_read_only:peak",
+        name="PostgreSQL heavy read-only peak throughput",
+        category="Database",
+        description=(
+            "Maximum PostgreSQL throughput over the pgbench concurrency profile "
+            "(typically 1, vCPUs/2, vCPUs, and 2*vCPUs) with a remote client against "
+            "a custom, cache-resident, read-only transaction (joins, aggregates, "
+            "full-text search, arrays, regex, TOAST) that fits in shared_buffers. "
+            "Server and client run in the same availability zone. Servers use "
+            "pgtune-style host GUCs, while DBaaS keep the vendor-managed config. "
+            "This is a synthetic proxy for relative RDBMS performance across server "
+            "types, not a prediction of any specific application's throughput."
+        ),
+        framework="pgbench",
+        measurement="heavy_read_only:peak",
+        source={"kind": "measured"},
         unit="Transactions per minute (TPM)",
     ),
 ]

--- a/src/sc_crawler/table_bases.py
+++ b/src/sc_crawler/table_bases.py
@@ -1477,13 +1477,9 @@ class BenchmarkScoreFields(HasBenchmarkPKFK, HasVendorPKFK):
         return ResourceIdComparator(cls, ResourceType.DATABASE, "database_id")
 
     def to_response(self) -> dict:
-        data = self.model_dump(exclude={"resource_type", "resource_id", "environment"})
+        data = self.model_dump(exclude={"resource_type", "resource_id"})
         resource_type = ResourceType(self.resource_type)
         data[f"{resource_type.value}_id"] = self.resource_id
-        if self.environment:
-            for key, value in self.environment.items():
-                if key not in data:
-                    data[key] = value
         return data
 
     @field_serializer("score_breakdown")

--- a/tests/test_benchmark_notes.py
+++ b/tests/test_benchmark_notes.py
@@ -1,0 +1,72 @@
+from sc_crawler.lookup import (
+    _BENCHMARK_FAMILY_INDEPENDENT_NOTE,
+    _BENCHMARK_LLM_SPEED_NOTE,
+    _BENCHMARK_SINGLE_SESSION_NOTE,
+    _BENCHMARK_SINGLE_THREAD_NOTE,
+    benchmarks,
+)
+
+
+def _bench(benchmark_id: str):
+    return next(b for b in benchmarks if b.benchmark_id == benchmark_id)
+
+
+def test_geekbench_scaling_notes():
+    assert "32 vCPUs" in _bench("geekbench:html5_browser").note
+    assert "4 vCPUs" in _bench("geekbench:text_processing").note
+    assert "64 vCPUs" in _bench("geekbench:score").note
+    assert _bench("geekbench:clang").note is None
+
+
+def test_passmark_scaling_notes():
+    assert "16 vCPUs" in _bench("passmark:memory_mark").note
+    assert _bench("passmark:memory_latency").note == _BENCHMARK_FAMILY_INDEPENDENT_NOTE
+    assert _bench("passmark:cpu_single_threaded_test").note == (
+        _BENCHMARK_SINGLE_THREAD_NOTE
+    )
+    assert _bench("passmark:cpu_compression_test").note is None
+
+
+def test_stress_ng_and_bogomips_notes():
+    assert _bench("stress_ng:best1").note == _BENCHMARK_SINGLE_THREAD_NOTE
+    assert _bench("stress_ng:bestn").note is None
+    assert "pseudo-benchmark" in _bench("bogomips").note
+
+
+def test_throughput_latency_notes():
+    redis_latency = _bench("redis:latency").note
+    assert "redis:rps" in redis_latency
+    assert "standalone benchmark" in redis_latency
+    assert "filter" in redis_latency
+
+    static_latency = _bench("static_web:latency").note
+    assert "static_web:rps" in static_latency
+    assert "filter" in static_latency
+    assert "listener bottleneck" not in static_latency
+
+    static_rps = _bench("static_web:rps").note
+    assert static_rps is not None
+    assert "listener bottleneck" in static_rps
+
+
+def test_llm_speed_notes():
+    text_gen = _bench("llm_speed:text_generation")
+    prompt = _bench("llm_speed:prompt_processing")
+    assert text_gen.note == _BENCHMARK_LLM_SPEED_NOTE
+    assert prompt.note == _BENCHMARK_LLM_SPEED_NOTE
+    assert "llama.cpp" in text_gen.note
+    assert "vLLM benchmarks" in text_gen.note
+
+
+def test_pgbench_notes_and_config_fields():
+    raw = _bench("pgbench:heavy_read_only")
+    single = _bench("pgbench:heavy_read_only:single")
+    peak = _bench("pgbench:heavy_read_only:peak")
+
+    assert "integer" in raw.config_fields["concurrency"].lower()
+    assert raw.note is None
+    assert single.note == _BENCHMARK_SINGLE_SESSION_NOTE
+    assert single.note != _BENCHMARK_SINGLE_THREAD_NOTE
+    assert peak.note is None
+    assert not single.config_fields
+    assert not peak.config_fields

--- a/tests/test_pgbench_benchmark_scores.py
+++ b/tests/test_pgbench_benchmark_scores.py
@@ -1,0 +1,82 @@
+import json
+from datetime import datetime, timezone
+
+from sc_crawler.inspector import _pgbench_benchmark_scores
+from sc_crawler.table_bases import ServerBase
+from sc_crawler.table_fields import Status
+
+
+def _sample_pgbench_json():
+    return {
+        "score": 12000.0,
+        "latency_avg_ms": 8.5,
+        "peak_concurrency": 8,
+        "postgres": {"server_version": "16.3 (Debian 16.3-1)"},
+        "sizes": [
+            {
+                "profile": [
+                    {"concurrency": 1, "score": 3000.0, "latency_avg_ms": 2.1},
+                    {"concurrency": 4, "score": 9000.0, "latency_avg_ms": 4.2},
+                    {"concurrency": 8, "score": 12000.0, "latency_avg_ms": 8.5},
+                    {"concurrency": 16, "score": 11000.0, "latency_avg_ms": 12.0},
+                ]
+            }
+        ],
+    }
+
+
+def test_pgbench_benchmark_scores_raw_single_and_peak(tmp_path, monkeypatch):
+    stdout = tmp_path / "stdout"
+    stdout.write_text(json.dumps(_sample_pgbench_json()))
+
+    monkeypatch.setattr(
+        "sc_crawler.inspector._server_framework_stdout_path",
+        lambda server, framework: stdout,
+    )
+    monkeypatch.setattr(
+        "sc_crawler.inspector._server_framework_meta",
+        lambda server, framework: {
+            "end": datetime(2026, 1, 1, tzinfo=timezone.utc),
+            "version": "16.3",
+            "kernel_version": "6.8.0",
+        },
+    )
+
+    server = ServerBase(
+        vendor_id="aws",
+        server_id="m5.large",
+        name="m5.large",
+        api_reference="m5.large",
+        display_name="m5.large",
+        description="test",
+        vcpus=8,
+        memory_amount=8192,
+        storage_size=0,
+        status=Status.ACTIVE,
+    )
+
+    scores = _pgbench_benchmark_scores(server)
+    by_id = {}
+    for score in scores:
+        by_id.setdefault(score["benchmark_id"], []).append(score)
+
+    raw = by_id["pgbench:heavy_read_only"]
+    assert len(raw) == 4
+    assert [r["config"]["concurrency"] for r in raw] == [1, 4, 8, 16]
+    assert all(isinstance(r["config"]["concurrency"], int) for r in raw)
+    assert [r["score"] for r in raw] == [3000.0, 9000.0, 12000.0, 11000.0]
+    assert raw[0]["note"] == "Latency: 2.1 ms."
+
+    single = by_id["pgbench:heavy_read_only:single"]
+    assert len(single) == 1
+    assert "config" not in single[0]
+    assert single[0]["score"] == 3000.0
+    assert single[0]["note"] == "Latency: 2.1 ms."
+
+    peak = by_id["pgbench:heavy_read_only:peak"]
+    assert len(peak) == 1
+    assert "config" not in peak[0]
+    assert peak[0]["score"] == 12000.0
+    assert peak[0]["note"] == "Latency: 8.5 ms, concurrency: 8."
+
+    assert peak[0]["environment"]["database_engine_version"] == "16.3"

--- a/tests/test_pgbench_benchmark_scores.py
+++ b/tests/test_pgbench_benchmark_scores.py
@@ -66,17 +66,26 @@ def test_pgbench_benchmark_scores_raw_single_and_peak(tmp_path, monkeypatch):
     assert all(isinstance(r["config"]["concurrency"], int) for r in raw)
     assert [r["score"] for r in raw] == [3000.0, 9000.0, 12000.0, 11000.0]
     assert raw[0]["note"] == "Latency: 2.1 ms."
+    assert [r["environment"]["latency_avg_ms"] for r in raw] == [2.1, 4.2, 8.5, 12.0]
+    assert all(r["environment"]["database_engine_version"] == "16.3" for r in raw)
+    assert all(r["environment"]["kernel_version"] == "6.8.0" for r in raw)
+    # Prove each row got its own environment dict (no shared-aliasing).
+    raw[0]["environment"]["latency_avg_ms"] = 999.0
+    assert raw[1]["environment"]["latency_avg_ms"] == 4.2
 
     single = by_id["pgbench:heavy_read_only:single"]
     assert len(single) == 1
     assert "config" not in single[0]
     assert single[0]["score"] == 3000.0
     assert single[0]["note"] == "Latency: 2.1 ms."
+    assert single[0]["environment"]["latency_avg_ms"] == 2.1
+    assert single[0]["environment"]["database_engine_version"] == "16.3"
 
     peak = by_id["pgbench:heavy_read_only:peak"]
     assert len(peak) == 1
     assert "config" not in peak[0]
     assert peak[0]["score"] == 12000.0
     assert peak[0]["note"] == "Latency: 8.5 ms, concurrency: 8."
-
+    assert peak[0]["environment"]["latency_avg_ms"] == 8.5
+    assert peak[0]["environment"]["peak_concurrency"] == 8
     assert peak[0]["environment"]["database_engine_version"] == "16.3"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -488,18 +488,18 @@ def test_benchmark_score_key_translation_and_hybrids():
         "benchmark_id": "bogomips",
         "config": {},
         "framework_version": None,
+        "environment": {"kernel_version": "6.8.0"},
         "score": 1.0,
         "score_breakdown": None,
         "note": None,
         "status": server_item.status,
         "observed_at": server_item.observed_at,
         "server_id": "m5.large",
-        "kernel_version": "6.8.0",
     }
     assert "database_id" not in response
     assert "resource_type" not in response
     assert "resource_id" not in response
-    assert "environment" not in response
+    assert "kernel_version" not in response
 
     db_item = BenchmarkScoreBase.model_validate(
         {
@@ -517,11 +517,11 @@ def test_benchmark_score_key_translation_and_hybrids():
 
     db_response = db_item.to_response()
     assert db_response["database_id"] == "db.m5.large"
-    assert db_response["database_engine_version"] == "16.3"
+    assert db_response["environment"] == {"database_engine_version": "16.3"}
+    assert "database_engine_version" not in db_response
     assert "server_id" not in db_response
     assert "resource_type" not in db_response
     assert "resource_id" not in db_response
-    assert "environment" not in db_response
 
     bare = BenchmarkScoreBase.model_validate(
         {
@@ -534,7 +534,7 @@ def test_benchmark_score_key_translation_and_hybrids():
     )
     bare_response = bare.to_response()
     assert bare_response["server_id"] == "t3.micro"
-    assert "environment" not in bare_response
+    assert bare_response["environment"] is None
     assert "kernel_version" not in bare_response
 
     constructed = BenchmarkScoreBase.model_construct(
@@ -548,7 +548,11 @@ def test_benchmark_score_key_translation_and_hybrids():
     )
     constructed_response = constructed.to_response()
     assert constructed_response["server_id"] == "m5.large"
-    assert constructed_response["kernel_version"] == "6.1.0"
+    assert constructed_response["environment"] == {
+        "server_id": "env-should-not-win",
+        "kernel_version": "6.1.0",
+    }
+    assert "kernel_version" not in constructed_response
 
     filter_sql = str(select(BenchmarkScore).where(BenchmarkScore.server_id == "x"))
     assert "resource_type" in filter_sql


### PR DESCRIPTION
# Overview

<!-- brief description of what the PR does if it's not clear from the PR title -->

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Benchmark score responses now include environment details as a nested field.
  * PostgreSQL heavy read-only benchmarks report configurable concurrency, average latency, and peak throughput.
  * Separate single-connection baseline and peak benchmark results are now available.
  * Package version updated to 0.9.1.

* **Bug Fixes**
  * Improved benchmark metadata and notes for clearer throughput, latency, and scaling information.

* **Tests**
  * Added coverage for benchmark notes, PostgreSQL results, environment data, latency, and concurrency metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->