### PR TITLE
Dev 829 new server status planned for retirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ New feature(s):
 
 - Extend `Status` with `PLANNED_FOR_RETIREMENT` and `RETIRED` for Server and
   Database (model validators reject these on other tables).
-  
+- Map vendor inventory onto those statuses from confirmed APIs and docs.
+ 
 ## v0.9.1 (August 14, 2026)
 
 ‼ Breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.9.1 (August 12, 2026)
+
+New feature(s):
+
+- Extend `Status` with `PLANNED_FOR_RETIREMENT` and `RETIRED` for Server and
+  Database (model validators reject these on other tables).
+
 ## v0.9.0 (August 10, 2026)
 
 ‼ Breaking changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.9.1 (August 12, 2026)
+## v0.9.2 (August 17, 2026)
 
 New feature(s):
 

--- a/docs/add_vendor.md
+++ b/docs/add_vendor.md
@@ -40,25 +40,11 @@ Other functions and variables must be prefixed with an underscore to suggest tho
 
 ## Status and retirement checks
 
-For `Server` and `Database`, `status` can be `ACTIVE`, `INACTIVE`, `PLANNED_FOR_RETIREMENT`, or `RETIRED`.
+Set `status` on every `Server` and `Database` row. Possible values: `ACTIVE`, `INACTIVE`, `PLANNED_FOR_RETIREMENT`, `RETIRED`.
 
-Current per-vendor lifecycle sources:
-
-- `AliCloud` server (`DescribeAvailableResource` `StatusCategory`): `WithStock` -> `ACTIVE`, `ClosedWithStock` -> `PLANNED_FOR_RETIREMENT`, `WithoutStock` -> `INACTIVE`, `ClosedWithoutStock` -> `RETIRED`; missing in availability response -> `INACTIVE`.
-- `AWS` server (`DescribeInstanceTypeOfferings`): not offered in any active region/zone -> `INACTIVE`; no type-level EC2 retirement API is used.
-- `AWS` database (`DescribeOrderableDBInstanceOptions`): no orderable options -> `RETIRED`; `_RDS_END_OF_SUPPORT_FAMILIES` -> `PLANNED_FOR_RETIREMENT`; otherwise -> `ACTIVE`.
-- `Azure` server + database: hardcoded lifecycle mappings (`_AZURE_RETIRED_SKU_PATTERNS` and announced SKU lists) -> `PLANNED_FOR_RETIREMENT` / `RETIRED`; otherwise `ACTIVE`.
-- `GCP` server (`machineTypes.deprecated.state`): `DEPRECATED` -> `PLANNED_FOR_RETIREMENT`, `OBSOLETE` / `DELETED` -> `RETIRED`, empty / `ACTIVE` -> `ACTIVE`.
-- `Hetzner` server (per-location server type fields): `deprecation.unavailable_after` in past -> `RETIRED`, `deprecation` present -> `PLANNED_FOR_RETIREMENT`, `available is False` or empty locations -> `INACTIVE`, otherwise `ACTIVE`.
-- `OVH` server (catalog plan `blobs.tags`): `active` tag -> `ACTIVE`, otherwise `INACTIVE` (`legacy` is not treated as retirement).
-- `UpCloud` server: `current_offering == "no"` -> `RETIRED`; GPU plans with zero stock in `/device/availability` across all regions -> `INACTIVE`; otherwise `ACTIVE`.
-- `Vultr` server: free plan or empty `locations` -> `INACTIVE`, otherwise `ACTIVE`.
-
-Rules:
-
-- Use only explicit API/doc lifecycle signals for `PLANNED_FOR_RETIREMENT` and `RETIRED`.
-- Do not infer retirement from naming patterns like "previous generation" unless there is an explicit mapping.
-- If multiple signals exist, best status wins: `ACTIVE` > `PLANNED_FOR_RETIREMENT` > `INACTIVE` > `RETIRED`.
+- Map the vendor's lifecycle API fields to these four states. Document the mapping in the `inventory_servers` / `inventory_databases` docstring.
+- Use only explicit API or documentation signals for `PLANNED_FOR_RETIREMENT` and `RETIRED`. Do not infer retirement from naming patterns like "previous generation" unless there is a confirmed mapping.
+- If multiple signals exist (e.g. per-region availability), pick the best: `ACTIVE` > `PLANNED_FOR_RETIREMENT` > `INACTIVE` > `RETIRED`.
 
 ## Progress bars
 

--- a/docs/add_vendor.md
+++ b/docs/add_vendor.md
@@ -38,6 +38,48 @@ The functions should return an array of dict representing the related objects. T
 
 Other functions and variables must be prefixed with an underscore to suggest those are internal tools.
 
+## Status and retirement checks
+
+For `Server` and `Database`, `status` can be `ACTIVE`, `INACTIVE`,
+`PLANNED_FOR_RETIREMENT`, or `RETIRED`.
+
+Current per-vendor lifecycle sources:
+
+- `AliCloud` (server): `DescribeAvailableResource` `StatusCategory` mapping:
+  `WithStock` -> `ACTIVE`, `ClosedWithStock` -> `PLANNED_FOR_RETIREMENT`,
+  `WithoutStock` -> `INACTIVE`, `ClosedWithoutStock` -> `RETIRED`.
+  If a type is missing from availability response, mark `INACTIVE`.
+- `AWS` (server): from `DescribeInstanceTypeOfferings`; not offered in any
+  active region/zone -> `INACTIVE`. No type-level EC2 retirement API is used.
+- `AWS` (database): from `DescribeOrderableDBInstanceOptions`; no orderable
+  options -> `RETIRED`. Families in `_RDS_END_OF_SUPPORT_FAMILIES` ->
+  `PLANNED_FOR_RETIREMENT`, otherwise `ACTIVE`.
+- `Azure` (server + database): hardcoded regex/name mappings from Azure VM
+  lifecycle docs (`_AZURE_RETIRED_SKU_PATTERNS`, announced lists) ->
+  `PLANNED_FOR_RETIREMENT` / `RETIRED`, else `ACTIVE`.
+- `GCP` (server): `machineTypes.deprecated.state` mapping:
+  `DEPRECATED` -> `PLANNED_FOR_RETIREMENT`, `OBSOLETE`/`DELETED` -> `RETIRED`,
+  empty/`ACTIVE` -> `ACTIVE`.
+- `Hetzner` (server): per-location fields from server types API:
+  `deprecation.unavailable_after` in past -> `RETIRED`,
+  `deprecation` present -> `PLANNED_FOR_RETIREMENT`,
+  `available is False` or empty locations -> `INACTIVE`, else `ACTIVE`.
+- `OVH` (server): catalog plan `blobs.tags` contains `active` -> `ACTIVE`,
+  otherwise `INACTIVE` (`legacy` is not treated as retirement).
+- `UpCloud` (server): `current_offering == "no"` -> `RETIRED`.
+  GPU plans are `INACTIVE` when `/device/availability` reports zero stock
+  across regions; otherwise `ACTIVE`.
+- `Vultr` (server): free plan or empty `locations` -> `INACTIVE`, else `ACTIVE`.
+
+Rules:
+
+- Use only explicit API/doc lifecycle signals for `PLANNED_FOR_RETIREMENT`
+  and `RETIRED`.
+- Do not infer retirement from naming patterns like "previous generation"
+  unless there is an explicit mapping.
+- If multiple signals exist, best status wins:
+  `ACTIVE` > `PLANNED_FOR_RETIREMENT` > `INACTIVE` > `RETIRED`.
+
 ## Progress bars
 
 To create progress bars, you can use the [Vendor][sc_crawler.tables.Vendor]'s [progress_tracker][sc_crawler.tables.Vendor.progress_tracker] attribute with the below methods:

--- a/docs/add_vendor.md
+++ b/docs/add_vendor.md
@@ -40,45 +40,25 @@ Other functions and variables must be prefixed with an underscore to suggest tho
 
 ## Status and retirement checks
 
-For `Server` and `Database`, `status` can be `ACTIVE`, `INACTIVE`,
-`PLANNED_FOR_RETIREMENT`, or `RETIRED`.
+For `Server` and `Database`, `status` can be `ACTIVE`, `INACTIVE`, `PLANNED_FOR_RETIREMENT`, or `RETIRED`.
 
 Current per-vendor lifecycle sources:
 
-- `AliCloud` (server): `DescribeAvailableResource` `StatusCategory` mapping:
-  `WithStock` -> `ACTIVE`, `ClosedWithStock` -> `PLANNED_FOR_RETIREMENT`,
-  `WithoutStock` -> `INACTIVE`, `ClosedWithoutStock` -> `RETIRED`.
-  If a type is missing from availability response, mark `INACTIVE`.
-- `AWS` (server): from `DescribeInstanceTypeOfferings`; not offered in any
-  active region/zone -> `INACTIVE`. No type-level EC2 retirement API is used.
-- `AWS` (database): from `DescribeOrderableDBInstanceOptions`; no orderable
-  options -> `RETIRED`. Families in `_RDS_END_OF_SUPPORT_FAMILIES` ->
-  `PLANNED_FOR_RETIREMENT`, otherwise `ACTIVE`.
-- `Azure` (server + database): hardcoded regex/name mappings from Azure VM
-  lifecycle docs (`_AZURE_RETIRED_SKU_PATTERNS`, announced lists) ->
-  `PLANNED_FOR_RETIREMENT` / `RETIRED`, else `ACTIVE`.
-- `GCP` (server): `machineTypes.deprecated.state` mapping:
-  `DEPRECATED` -> `PLANNED_FOR_RETIREMENT`, `OBSOLETE`/`DELETED` -> `RETIRED`,
-  empty/`ACTIVE` -> `ACTIVE`.
-- `Hetzner` (server): per-location fields from server types API:
-  `deprecation.unavailable_after` in past -> `RETIRED`,
-  `deprecation` present -> `PLANNED_FOR_RETIREMENT`,
-  `available is False` or empty locations -> `INACTIVE`, else `ACTIVE`.
-- `OVH` (server): catalog plan `blobs.tags` contains `active` -> `ACTIVE`,
-  otherwise `INACTIVE` (`legacy` is not treated as retirement).
-- `UpCloud` (server): `current_offering == "no"` -> `RETIRED`.
-  GPU plans are `INACTIVE` when `/device/availability` reports zero stock
-  across regions; otherwise `ACTIVE`.
-- `Vultr` (server): free plan or empty `locations` -> `INACTIVE`, else `ACTIVE`.
+- `AliCloud` server (`DescribeAvailableResource` `StatusCategory`): `WithStock` -> `ACTIVE`, `ClosedWithStock` -> `PLANNED_FOR_RETIREMENT`, `WithoutStock` -> `INACTIVE`, `ClosedWithoutStock` -> `RETIRED`; missing in availability response -> `INACTIVE`.
+- `AWS` server (`DescribeInstanceTypeOfferings`): not offered in any active region/zone -> `INACTIVE`; no type-level EC2 retirement API is used.
+- `AWS` database (`DescribeOrderableDBInstanceOptions`): no orderable options -> `RETIRED`; `_RDS_END_OF_SUPPORT_FAMILIES` -> `PLANNED_FOR_RETIREMENT`; otherwise -> `ACTIVE`.
+- `Azure` server + database: hardcoded lifecycle mappings (`_AZURE_RETIRED_SKU_PATTERNS` and announced SKU lists) -> `PLANNED_FOR_RETIREMENT` / `RETIRED`; otherwise `ACTIVE`.
+- `GCP` server (`machineTypes.deprecated.state`): `DEPRECATED` -> `PLANNED_FOR_RETIREMENT`, `OBSOLETE` / `DELETED` -> `RETIRED`, empty / `ACTIVE` -> `ACTIVE`.
+- `Hetzner` server (per-location server type fields): `deprecation.unavailable_after` in past -> `RETIRED`, `deprecation` present -> `PLANNED_FOR_RETIREMENT`, `available is False` or empty locations -> `INACTIVE`, otherwise `ACTIVE`.
+- `OVH` server (catalog plan `blobs.tags`): `active` tag -> `ACTIVE`, otherwise `INACTIVE` (`legacy` is not treated as retirement).
+- `UpCloud` server: `current_offering == "no"` -> `RETIRED`; GPU plans with zero stock in `/device/availability` across all regions -> `INACTIVE`; otherwise `ACTIVE`.
+- `Vultr` server: free plan or empty `locations` -> `INACTIVE`, otherwise `ACTIVE`.
 
 Rules:
 
-- Use only explicit API/doc lifecycle signals for `PLANNED_FOR_RETIREMENT`
-  and `RETIRED`.
-- Do not infer retirement from naming patterns like "previous generation"
-  unless there is an explicit mapping.
-- If multiple signals exist, best status wins:
-  `ACTIVE` > `PLANNED_FOR_RETIREMENT` > `INACTIVE` > `RETIRED`.
+- Use only explicit API/doc lifecycle signals for `PLANNED_FOR_RETIREMENT` and `RETIRED`.
+- Do not infer retirement from naming patterns like "previous generation" unless there is an explicit mapping.
+- If multiple signals exist, best status wins: `ACTIVE` > `PLANNED_FOR_RETIREMENT` > `INACTIVE` > `RETIRED`.
 
 ## Progress bars
 

--- a/src/sc_crawler/__init__.py
+++ b/src/sc_crawler/__init__.py
@@ -1,4 +1,4 @@
 """Spare Cores crawler: collect and standardize cloud server offerings data."""
 
-__version__ = "0.9.1"
+__version__ = "0.9.2"
 __version_info__ = tuple(int(x) for x in __version__.split(".")[:3])

--- a/src/sc_crawler/__init__.py
+++ b/src/sc_crawler/__init__.py
@@ -1,4 +1,4 @@
 """Spare Cores crawler: collect and standardize cloud server offerings data."""
 
-__version__ = "0.9.0"
+__version__ = "0.9.1"
 __version_info__ = tuple(int(x) for x in __version__.split(".")[:3])

--- a/src/sc_crawler/alembic/versions/b1c2d3e4f5a6_v0_9_1_extend_status_enum.py
+++ b/src/sc_crawler/alembic/versions/b1c2d3e4f5a6_v0_9_1_extend_status_enum.py
@@ -1,0 +1,92 @@
+"""v0.9.1 extend status enum for server/database retirement
+
+Revision ID: b1c2d3e4f5a6
+Revises: a9b0c1d2e3f4
+Create Date: 2026-08-12 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "b1c2d3e4f5a6"
+down_revision: Union[str, None] = "a9b0c1d2e3f4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_STATUS_TABLES = (
+    "benchmark",
+    "benchmark_score",
+    "compliance_framework",
+    "country",
+    "database",
+    "database_price",
+    "database_storage",
+    "database_storage_price",
+    "ipv4_price",
+    "region",
+    "server",
+    "server_description",
+    "server_price",
+    "storage",
+    "storage_price",
+    "traffic_price",
+    "vendor",
+    "vendor_compliance_link",
+    "zone",
+)
+
+
+def is_scd_migration() -> bool:
+    return bool(op.get_context().config.attributes.get("scd"))
+
+
+def scdize_suffix(table_name: str) -> str:
+    if is_scd_migration():
+        return table_name + "_scd"
+    return table_name
+
+
+def upgrade() -> None:
+    if op.get_context().dialect.name != "postgresql":
+        return
+    # SQLAlchemy stores Status member names (ACTIVE, …), not values.
+    op.execute("ALTER TYPE status ADD VALUE IF NOT EXISTS 'PLANNED_FOR_RETIREMENT'")
+    op.execute("ALTER TYPE status ADD VALUE IF NOT EXISTS 'RETIRED'")
+
+
+def downgrade() -> None:
+    if op.get_context().dialect.name != "postgresql":
+        return
+
+    for table in ("server", "database"):
+        table_name = scdize_suffix(table)
+        op.execute(
+            f"""
+            UPDATE {table_name}
+            SET status = 'ACTIVE'
+            WHERE status = 'PLANNED_FOR_RETIREMENT'
+            """  # noqa: S608
+        )
+        op.execute(
+            f"""
+            UPDATE {table_name}
+            SET status = 'INACTIVE'
+            WHERE status = 'RETIRED'
+            """  # noqa: S608
+        )
+
+    # All status columns must be retyped when recreating the enum.
+    op.execute("ALTER TYPE status RENAME TO status_old")
+    op.execute("CREATE TYPE status AS ENUM ('ACTIVE', 'INACTIVE')")
+    for table in _STATUS_TABLES:
+        table_name = scdize_suffix(table)
+        op.execute(
+            f"""
+            ALTER TABLE {table_name}
+            ALTER COLUMN status TYPE status
+            USING status::text::status
+            """  # noqa: S608
+        )
+    op.execute("DROP TYPE status_old")

--- a/src/sc_crawler/alembic/versions/b1c2d3e4f5a6_v0_9_2_extend_status_enum.py
+++ b/src/sc_crawler/alembic/versions/b1c2d3e4f5a6_v0_9_2_extend_status_enum.py
@@ -1,4 +1,4 @@
-"""v0.9.1 extend status enum for server/database retirement
+"""v0.9.2 extend status enum for server/database retirement
 
 Revision ID: b1c2d3e4f5a6
 Revises: a9b0c1d2e3f4

--- a/src/sc_crawler/table_bases.py
+++ b/src/sc_crawler/table_bases.py
@@ -21,7 +21,6 @@ from sqlmodel import JSON, Field, Session, SQLModel, select
 
 from .str_utils import snake_case
 from .table_fields import (
-    GENERAL_STATUSES,
     Allocation,
     Category,
     Cpu,
@@ -239,7 +238,7 @@ class MetaColumns(ScModel):
     @field_validator("status")
     @classmethod
     def _validate_status(cls, value: Status) -> Status:
-        if value not in GENERAL_STATUSES:
+        if not value.is_general:
             raise ValueError(
                 f"{value!r} is only valid for Server and Database. "
                 f"Use ACTIVE or INACTIVE for {cls.__name__}."

--- a/src/sc_crawler/table_bases.py
+++ b/src/sc_crawler/table_bases.py
@@ -21,6 +21,7 @@ from sqlmodel import JSON, Field, Session, SQLModel, select
 
 from .str_utils import snake_case
 from .table_fields import (
+    GENERAL_STATUSES,
     Allocation,
     Category,
     Cpu,
@@ -34,7 +35,6 @@ from .table_fields import (
     DatabaseWireProtocol,
     DdrGeneration,
     Disk,
-    GENERAL_STATUSES,
     Gpu,
     HashableDict,
     HashableJSON,

--- a/src/sc_crawler/table_bases.py
+++ b/src/sc_crawler/table_bases.py
@@ -34,6 +34,7 @@ from .table_fields import (
     DatabaseWireProtocol,
     DdrGeneration,
     Disk,
+    GENERAL_STATUSES,
     Gpu,
     HashableDict,
     HashableJSON,
@@ -234,6 +235,16 @@ class MetaColumns(ScModel):
         sa_column_kwargs={"onupdate": lambda: datetime.now(UTC)},
         description="Timestamp of the last observation.",
     )
+
+    @field_validator("status")
+    @classmethod
+    def _validate_status(cls, value: Status) -> Status:
+        if value not in GENERAL_STATUSES:
+            raise ValueError(
+                f"{value!r} is only valid for Server and Database. "
+                f"Use ACTIVE or INACTIVE for {cls.__name__}."
+            )
+        return value
 
 
 class HasComplianceFrameworkIdPK(ScModel):
@@ -876,7 +887,10 @@ class ServerFields(
 
 
 class ServerBase(MetaColumns, ServerFields):
-    pass
+    @field_validator("status")
+    @classmethod
+    def _validate_status(cls, value: Status) -> Status:
+        return value
 
 
 class ServerPriceFields(ScModel):
@@ -1097,7 +1111,10 @@ class DatabaseFields(
 
 
 class DatabaseBase(MetaColumns, DatabaseFields):
-    pass
+    @field_validator("status")
+    @classmethod
+    def _validate_status(cls, value: Status) -> Status:
+        return value
 
 
 class DatabasePriceFields(ScModel):

--- a/src/sc_crawler/table_fields.py
+++ b/src/sc_crawler/table_fields.py
@@ -51,7 +51,7 @@ class Status(str, Enum):
     ACTIVE = "active"
     """Active and available resource."""
     INACTIVE = "inactive"
-    """Inactive resource that is not available anymore."""
+    """Unavailable. For Server/Database: temporary or unknown cause."""
     PLANNED_FOR_RETIREMENT = "planned-for-retirement"
     """Planned for retirement; only valid for Server and Database."""
     RETIRED = "retired"

--- a/src/sc_crawler/table_fields.py
+++ b/src/sc_crawler/table_fields.py
@@ -75,9 +75,10 @@ class Status(str, Enum):
         """Whether a Server/Database with this status can still be ordered."""
         return self in (Status.ACTIVE, Status.PLANNED_FOR_RETIREMENT)
 
-
-# ACTIVE / INACTIVE only — used by MetaColumns validator for non-server/database models.
-GENERAL_STATUSES = frozenset({Status.ACTIVE, Status.INACTIVE})
+    @property
+    def is_general(self) -> bool:
+        """Whether this status is valid for non-server/database models (ACTIVE or INACTIVE only)."""
+        return self in (Status.ACTIVE, Status.INACTIVE)
 
 
 class ResourceType(str, Enum):

--- a/src/sc_crawler/table_fields.py
+++ b/src/sc_crawler/table_fields.py
@@ -52,6 +52,14 @@ class Status(str, Enum):
     """Active and available resource."""
     INACTIVE = "inactive"
     """Inactive resource that is not available anymore."""
+    PLANNED_FOR_RETIREMENT = "planned-for-retirement"
+    """Planned for retirement; only valid for Server and Database."""
+    RETIRED = "retired"
+    """Not orderable anymore, but prices may still exist (e.g. active multi-year contracts). Only valid for Server and Database."""
+
+
+# ACTIVE / INACTIVE only — used by MetaColumns validator for non-server/database models.
+GENERAL_STATUSES = frozenset({Status.ACTIVE, Status.INACTIVE})
 
 
 class ResourceType(str, Enum):

--- a/src/sc_crawler/table_fields.py
+++ b/src/sc_crawler/table_fields.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 from json import dumps
-from typing import Any, List, Optional
+from typing import Any, Collection, List, Optional
 
 from pydantic import BaseModel, field_serializer, field_validator
 from sqlalchemy.types import TypeDecorator
@@ -56,6 +56,24 @@ class Status(str, Enum):
     """Planned for retirement; only valid for Server and Database."""
     RETIRED = "retired"
     """Not orderable anymore, but prices may still exist (e.g. active multi-year contracts). Only valid for Server and Database."""
+
+    @classmethod
+    def best(cls, statuses: Collection["Status"]) -> "Status":
+        """Return the best of the given statuses: ACTIVE, PLANNED_FOR_RETIREMENT, INACTIVE, then RETIRED."""
+        for status in (
+            cls.ACTIVE,
+            cls.PLANNED_FOR_RETIREMENT,
+            cls.INACTIVE,
+            cls.RETIRED,
+        ):
+            if status in statuses:
+                return status
+        raise ValueError("statuses is empty")
+
+    @property
+    def is_orderable(self) -> bool:
+        """Whether a Server/Database with this status can still be ordered."""
+        return self in (Status.ACTIVE, Status.PLANNED_FOR_RETIREMENT)
 
 
 # ACTIVE / INACTIVE only — used by MetaColumns validator for non-server/database models.

--- a/src/sc_crawler/tables.py
+++ b/src/sc_crawler/tables.py
@@ -329,7 +329,7 @@ class Vendor(VendorBase, table=True):
             BenchmarkScore.vendor_id == self.vendor_id,
             BenchmarkScore.resource_type == ResourceType.SERVER,
         )
-        insert_items(BenchmarkScore, benchmarks, self)
+        insert_items(BenchmarkScore, benchmarks, self, prefix="server")
         self.progress_tracker.start_task(
             name="Downloading sc-navigator-descriptions", total=None
         )
@@ -421,7 +421,7 @@ class Vendor(VendorBase, table=True):
             BenchmarkScore.vendor_id == self.vendor_id,
             BenchmarkScore.resource_type == ResourceType.DATABASE,
         )
-        insert_items(BenchmarkScore, benchmarks, self)
+        insert_items(BenchmarkScore, benchmarks, self, prefix="database")
 
     @log_start_end
     def inventory_database_prices(self):

--- a/src/sc_crawler/vendor_helpers.py
+++ b/src/sc_crawler/vendor_helpers.py
@@ -10,7 +10,7 @@ def server_status_from_availability_categories(
     categories: Collection[str],
     category_to_status: Mapping[str, Status],
     *,
-    missing_status: Status = Status.RETIRED,
+    missing_status: Status = Status.INACTIVE,
 ) -> Status:
     """Map vendor availability categories to a single Server/Database status.
 

--- a/src/sc_crawler/vendor_helpers.py
+++ b/src/sc_crawler/vendor_helpers.py
@@ -9,20 +9,18 @@ from .tables import Region, Vendor
 def server_status_from_availability_categories(
     categories: Collection[str],
     category_to_status: Mapping[str, Status],
-    status_priority: tuple[Status, ...],
     *,
     missing_status: Status = Status.RETIRED,
 ) -> Status:
     """Map vendor availability categories to a single Server/Database status.
 
     Each category is mapped via ``category_to_status``. If more than one
-    status results, ``status_priority`` (best first) selects the best.
-    Empty or unmapped ``categories`` return ``missing_status``.
+    status results, ``Status.best`` selects the best. Empty or unmapped
+    ``categories`` return ``missing_status``.
     """
     if not categories:
         return missing_status
 
-    priority = {status: index for index, status in enumerate(status_priority)}
     mapped = {
         category_to_status[category]
         for category in categories
@@ -31,17 +29,7 @@ def server_status_from_availability_categories(
     if not mapped:
         return missing_status
 
-    return min(mapped, key=lambda status: priority[status])
-
-
-def server_price_status_from_availability_category(
-    category: Optional[str],
-    orderable_categories: frozenset[str],
-) -> Status:
-    """Map a per-zone availability category to ServerPrice ACTIVE/INACTIVE."""
-    if category in orderable_categories:
-        return Status.ACTIVE
-    return Status.INACTIVE
+    return Status.best(mapped)
 
 
 def fetch_servers(fn: Callable, where: str, vendor: Optional[Vendor]) -> List[dict]:

--- a/src/sc_crawler/vendor_helpers.py
+++ b/src/sc_crawler/vendor_helpers.py
@@ -1,9 +1,47 @@
 from concurrent.futures import ThreadPoolExecutor
 from itertools import chain, repeat
-from typing import Callable, List, Literal, Optional
+from typing import Callable, Collection, List, Literal, Mapping, Optional
 
 from .table_fields import Status
 from .tables import Region, Vendor
+
+
+def server_status_from_availability_categories(
+    categories: Collection[str],
+    category_to_status: Mapping[str, Status],
+    status_priority: tuple[Status, ...],
+    *,
+    missing_status: Status = Status.RETIRED,
+) -> Status:
+    """Map vendor availability categories to a single Server/Database status.
+
+    Each category is mapped via ``category_to_status``. If more than one
+    status results, ``status_priority`` (best first) selects the best.
+    Empty or unmapped ``categories`` return ``missing_status``.
+    """
+    if not categories:
+        return missing_status
+
+    priority = {status: index for index, status in enumerate(status_priority)}
+    mapped = {
+        category_to_status[category]
+        for category in categories
+        if category in category_to_status
+    }
+    if not mapped:
+        return missing_status
+
+    return min(mapped, key=lambda status: priority[status])
+
+
+def server_price_status_from_availability_category(
+    category: Optional[str],
+    orderable_categories: frozenset[str],
+) -> Status:
+    """Map a per-zone availability category to ServerPrice ACTIVE/INACTIVE."""
+    if category in orderable_categories:
+        return Status.ACTIVE
+    return Status.INACTIVE
 
 
 def fetch_servers(fn: Callable, where: str, vendor: Optional[Vendor]) -> List[dict]:

--- a/src/sc_crawler/vendors/_alicloud.py
+++ b/src/sc_crawler/vendors/_alicloud.py
@@ -834,7 +834,12 @@ def inventory_zones(vendor):
 
 
 def inventory_servers(vendor):
-    """List all server types at Alibaba Cloud using the `DescribeInstanceTypes` API endpoint."""
+    """List all server types at Alibaba Cloud using the `DescribeInstanceTypes` API endpoint.
+
+    Lifecycle (`DescribeAvailableResource` `StatusCategory`): WithStock -> ACTIVE,
+    ClosedWithStock -> PLANNED_FOR_RETIREMENT, WithoutStock -> INACTIVE,
+    ClosedWithoutStock -> RETIRED; missing in availability response -> INACTIVE.
+    """
     client = _ecs_client()
     additional_attributes = ["NetworkInfo.BandwidthWeighting"]
     request = DescribeInstanceTypesRequest(

--- a/src/sc_crawler/vendors/_alicloud.py
+++ b/src/sc_crawler/vendors/_alicloud.py
@@ -49,7 +49,35 @@ from ..table_fields import (
 )
 from ..tables import ServerPrice, Vendor
 from ..utils import _GIB_TO_GB, _HOURS_PER_MONTH, jsoned_hash
-from ..vendor_helpers import get_region_by_id
+from ..vendor_helpers import (
+    get_region_by_id,
+    server_price_status_from_availability_category,
+    server_status_from_availability_categories,
+)
+
+# StatusCategory values:
+# *   WithStock: The resources are available and can be continuously
+#     replenished.
+# *   ClosedWithStock: Inventory is available, but resources will not be
+#     replenished. The ability to guarantee the supply of inventory is low.
+#     We recommend selecting a product specification in the WithStock state.
+# *   WithoutStock: The resource is out of stock and will be replenished.
+#     We recommend using other resources that are in stock.
+# *   ClosedWithoutStock: The resource is out of stock and will no longer
+#     be replenished. We recommend using other resources that are in stock.
+_ALICLOUD_STATUS_CATEGORY_TO_SERVER_STATUS = {
+    "WithStock": Status.ACTIVE,
+    "ClosedWithStock": Status.PLANNED_FOR_RETIREMENT,
+    "WithoutStock": Status.INACTIVE,
+    "ClosedWithoutStock": Status.RETIRED,
+}
+_ALICLOUD_SERVER_STATUS_PRIORITY = (
+    Status.ACTIVE,
+    Status.PLANNED_FOR_RETIREMENT,
+    Status.INACTIVE,
+    Status.RETIRED,
+)
+_ALICLOUD_ORDERABLE_STATUS_CATEGORIES = frozenset({"WithStock", "ClosedWithStock"})
 
 # ##############################################################################
 # Internal helpers
@@ -251,26 +279,16 @@ def _get_region_availability_info(
     return region_availability_info
 
 
-def _is_resource_available(
+def _get_resource_status_category(
     region_availability_info: dict[str, list[dict]],
     region_id: str,
     zone_id: str,
     server_id: str,
     resource_type: str = "InstanceType",
-    status_category: str = "WithStock",
-) -> bool:
-    """Check if a specific resource is available in a specific region and zone.
-
-    Args:
-        region_availability_info: The region availability information.
-        region_id: The region ID.
-        zone_id: The zone ID.
-        server_id: The server ID.
-        resource_type: The resource type, defaults to "InstanceType".
-        status_category: The status category to check for, defaults to "WithStock".
-    """
+) -> Optional[str]:
+    """Return AliCloud StatusCategory for a resource in a region/zone, if listed."""
     if not region_availability_info:
-        return False
+        return None
 
     zone_availability_info = next(
         (
@@ -280,9 +298,8 @@ def _is_resource_available(
         ),
         None,
     )
-
     if not zone_availability_info:
-        return False
+        return None
 
     available_resource: list[dict] = zone_availability_info.get(
         "AvailableResources", {}
@@ -299,24 +316,12 @@ def _is_resource_available(
 
     server_info = next(
         (r for r in supported_resource if r.get("Value") == server_id),
-        {},
+        None,
     )
+    if not server_info:
+        return None
 
-    # StatusCategory values:
-    # *   WithStock: The resources are available and can be continuously
-    #     replenished.
-    # *   ClosedWithStock: Inventory is available, but resources will not be
-    #     replenished. The ability to guarantee the supply of inventory is low.
-    #     We recommend selecting a product specification in the WithStock state.
-    # *   WithoutStock: The resource is out of stock and will be replenished.
-    #     We recommend using other resources that are in stock.
-    # *   ClosedWithoutStock: The resource is out of stock and will no longer
-    #     be replenished. We recommend using other resources that are in stock.
-
-    if server_info.get("StatusCategory") == status_category:
-        return True
-
-    return False
+    return server_info.get("StatusCategory")
 
 
 def _get_spot_advices(
@@ -987,19 +992,23 @@ def inventory_servers(vendor):
         ]
         description = f"{family} family ({', '.join(filter(None, description_parts))})"
         server_id = instance_type.get("InstanceTypeId")
-        status = (
-            Status.ACTIVE
-            if any(
-                _is_resource_available(
+        status_categories = {
+            category
+            for region_id, zones in region_availability_info.items()
+            for zone_info in zones
+            if (
+                category := _get_resource_status_category(
                     region_availability_info,
                     region_id,
                     zone_info.get("ZoneId"),
                     server_id,
                 )
-                for region_id, zones in region_availability_info.items()
-                for zone_info in zones
             )
-            else Status.INACTIVE
+        }
+        status = server_status_from_availability_categories(
+            status_categories,
+            _ALICLOUD_STATUS_CATEGORY_TO_SERVER_STATUS,
+            _ALICLOUD_SERVER_STATUS_PRIORITY,
         )
 
         items.append(
@@ -1079,12 +1088,14 @@ def inventory_server_prices(vendor):
             continue
         for zone in region.zones:
             server_id = sku.get("SkuFactorMap", {}).get("instance_type")
-            status = (
-                Status.ACTIVE
-                if _is_resource_available(
-                    region_availability_info, region.region_id, zone.zone_id, server_id
-                )
-                else Status.INACTIVE
+            status = server_price_status_from_availability_category(
+                _get_resource_status_category(
+                    region_availability_info,
+                    region.region_id,
+                    zone.zone_id,
+                    server_id,
+                ),
+                _ALICLOUD_ORDERABLE_STATUS_CATEGORIES,
             )
 
             items.append(
@@ -1115,12 +1126,12 @@ def inventory_server_prices(vendor):
         counts = status_by_region[region_id]
         vendor.log(
             f"{region_id}: Found {counts[Status.ACTIVE]} ACTIVE and "
-            f"{counts[Status.INACTIVE]} INACTIVE server prices",
+            f"{counts[Status.INACTIVE]} INACTIVE on-demand server prices",
             level=INFO,
         )
     vendor.log(
         f"OVERALL: Found {overall[Status.ACTIVE]} ACTIVE and "
-        f"{overall[Status.INACTIVE]} INACTIVE server prices",
+        f"{overall[Status.INACTIVE]} INACTIVE on-demand server prices",
         level=INFO,
     )
     return items

--- a/src/sc_crawler/vendors/_alicloud.py
+++ b/src/sc_crawler/vendors/_alicloud.py
@@ -51,7 +51,6 @@ from ..tables import ServerPrice, Vendor
 from ..utils import _GIB_TO_GB, _HOURS_PER_MONTH, jsoned_hash
 from ..vendor_helpers import (
     get_region_by_id,
-    server_price_status_from_availability_category,
     server_status_from_availability_categories,
 )
 
@@ -71,13 +70,6 @@ _ALICLOUD_STATUS_CATEGORY_TO_SERVER_STATUS = {
     "WithoutStock": Status.INACTIVE,
     "ClosedWithoutStock": Status.RETIRED,
 }
-_ALICLOUD_SERVER_STATUS_PRIORITY = (
-    Status.ACTIVE,
-    Status.PLANNED_FOR_RETIREMENT,
-    Status.INACTIVE,
-    Status.RETIRED,
-)
-_ALICLOUD_ORDERABLE_STATUS_CATEGORIES = frozenset({"WithStock", "ClosedWithStock"})
 
 # ##############################################################################
 # Internal helpers
@@ -1008,7 +1000,6 @@ def inventory_servers(vendor):
         status = server_status_from_availability_categories(
             status_categories,
             _ALICLOUD_STATUS_CATEGORY_TO_SERVER_STATUS,
-            _ALICLOUD_SERVER_STATUS_PRIORITY,
         )
 
         items.append(
@@ -1088,15 +1079,16 @@ def inventory_server_prices(vendor):
             continue
         for zone in region.zones:
             server_id = sku.get("SkuFactorMap", {}).get("instance_type")
-            status = server_price_status_from_availability_category(
-                _get_resource_status_category(
-                    region_availability_info,
-                    region.region_id,
-                    zone.zone_id,
-                    server_id,
-                ),
-                _ALICLOUD_ORDERABLE_STATUS_CATEGORIES,
+            category = _get_resource_status_category(
+                region_availability_info,
+                region.region_id,
+                zone.zone_id,
+                server_id,
             )
+            mapped = _ALICLOUD_STATUS_CATEGORY_TO_SERVER_STATUS.get(
+                category or "", Status.INACTIVE
+            )
+            status = Status.ACTIVE if mapped.is_orderable else Status.INACTIVE
 
             items.append(
                 {

--- a/src/sc_crawler/vendors/_aws.py
+++ b/src/sc_crawler/vendors/_aws.py
@@ -222,31 +222,9 @@ _instance_suffixes = {
     "flex": "Flex instance",
 }
 
-# Previous-generation EC2 families.
-# https://docs.aws.amazon.com/ec2/latest/instancetypes/instance-types.html
-_EC2_PLANNED_FOR_RETIREMENT_FAMILIES = frozenset(
-    {
-        "a1",
-        "c1",
-        "c3",
-        "c4",
-        "g3",
-        "i2",
-        "m1",
-        "m2",
-        "m3",
-        "m4",
-        "p3",
-        "p3dn",
-        "r3",
-        "r4",
-        "t1",
-    }
-)
-
-# RDS instance classes with documented end-of-support.
+# RDS instance classes with an announced end-of-support schedule.
 # https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.Types.html
-_RDS_PLANNED_FOR_RETIREMENT_FAMILIES = frozenset(
+_RDS_END_OF_SUPPORT_FAMILIES = frozenset(
     {
         "db.m3",
         "db.m4",
@@ -427,11 +405,6 @@ def _make_server_from_instance_type(instance_type, vendor) -> dict:
         "network_speed_max": network_card["PeakBandwidthInGbps"],
         "network_storage_speed_baseline": ebs_baseline_gbps,
         "network_storage_speed_max": ebs_max_gbps,
-        "status": (
-            Status.PLANNED_FOR_RETIREMENT
-            if it.split(".")[0] in _EC2_PLANNED_FOR_RETIREMENT_FAMILIES
-            else Status.ACTIVE
-        ),
     }
 
 
@@ -1082,14 +1055,16 @@ def inventory_server_prices(vendor):
             vendor.progress_tracker.advance_task()
     vendor.progress_tracker.hide_task()
 
-    priced_server_ids = {item["server_id"] for item in server_prices}
+    # Not offered in any ACTIVE region/zone. AWS does not confirm retirement,
+    # so mark INACTIVE rather than RETIRED. Prices may still be published.
+    offered_server_ids = {
+        server_id
+        for zone_servers in regions_servers.values()
+        for server_id in zone_servers
+    }
     for server in vendor.servers:
-        if server.server_id in priced_server_ids:
-            continue
-        if server.status == Status.ACTIVE:
+        if server.server_id not in offered_server_ids:
             server.status = Status.INACTIVE
-        elif server.status == Status.PLANNED_FOR_RETIREMENT:
-            server.status = Status.RETIRED
 
     return server_prices
 
@@ -1638,14 +1613,12 @@ def inventory_databases(vendor):
                 continue
             seen_database_ids.add(database_id)
             db_instance_options = options_by_database.get(database_id, [])
-            status = (
-                Status.PLANNED_FOR_RETIREMENT
-                if ".".join(database_id.split(".")[:2])
-                in _RDS_PLANNED_FOR_RETIREMENT_FAMILIES
-                else Status.ACTIVE
-            )
             if not db_instance_options:
-                status = Status.INACTIVE if status == Status.ACTIVE else Status.RETIRED
+                status = Status.RETIRED
+            elif ".".join(database_id.split(".")[:2]) in _RDS_END_OF_SUPPORT_FAMILIES:
+                status = Status.PLANNED_FOR_RETIREMENT
+            else:
+                status = Status.ACTIVE
             deployment_options = deployment_options_by_database.get(
                 database_id, frozenset()
             )

--- a/src/sc_crawler/vendors/_aws.py
+++ b/src/sc_crawler/vendors/_aws.py
@@ -222,6 +222,40 @@ _instance_suffixes = {
     "flex": "Flex instance",
 }
 
+# Previous-generation EC2 families.
+# https://docs.aws.amazon.com/ec2/latest/instancetypes/instance-types.html
+_EC2_PLANNED_FOR_RETIREMENT_FAMILIES = frozenset(
+    {
+        "a1",
+        "c1",
+        "c3",
+        "c4",
+        "g3",
+        "i2",
+        "m1",
+        "m2",
+        "m3",
+        "m4",
+        "p3",
+        "p3dn",
+        "r3",
+        "r4",
+        "t1",
+    }
+)
+
+# RDS instance classes with documented end-of-support.
+# https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.Types.html
+_RDS_PLANNED_FOR_RETIREMENT_FAMILIES = frozenset(
+    {
+        "db.m3",
+        "db.m4",
+        "db.r3",
+        "db.r4",
+        "db.t2",
+    }
+)
+
 
 def _annotate_instance_type(instance_type_id):
     """Resolve instance type coding to human-friendly description.
@@ -393,6 +427,11 @@ def _make_server_from_instance_type(instance_type, vendor) -> dict:
         "network_speed_max": network_card["PeakBandwidthInGbps"],
         "network_storage_speed_baseline": ebs_baseline_gbps,
         "network_storage_speed_max": ebs_max_gbps,
+        "status": (
+            Status.PLANNED_FOR_RETIREMENT
+            if it.split(".")[0] in _EC2_PLANNED_FOR_RETIREMENT_FAMILIES
+            else Status.ACTIVE
+        ),
     }
 
 
@@ -1042,6 +1081,16 @@ def inventory_server_prices(vendor):
         finally:
             vendor.progress_tracker.advance_task()
     vendor.progress_tracker.hide_task()
+
+    priced_server_ids = {item["server_id"] for item in server_prices}
+    for server in vendor.servers:
+        if server.server_id in priced_server_ids:
+            continue
+        if server.status == Status.ACTIVE:
+            server.status = Status.INACTIVE
+        elif server.status == Status.PLANNED_FOR_RETIREMENT:
+            server.status = Status.RETIRED
+
     return server_prices
 
 
@@ -1454,8 +1503,7 @@ def _lookup_orderable_db_instance_options(
         {
             database_id
             for region_classes in prices_by_region.values()
-            for database_id, attrs in region_classes.items()
-            if attrs.get("currentGeneration") == "Yes"
+            for database_id in region_classes
         }
     )
     vendor.progress_tracker.start_task(
@@ -1590,11 +1638,14 @@ def inventory_databases(vendor):
                 continue
             seen_database_ids.add(database_id)
             db_instance_options = options_by_database.get(database_id, [])
-            status = Status.ACTIVE
-            # Pricing keeps previous-gen SKUs (currentGeneration=No) after AWS stops
-            # allowing new launches; add these classes with INACTIVE status.
+            status = (
+                Status.PLANNED_FOR_RETIREMENT
+                if ".".join(database_id.split(".")[:2])
+                in _RDS_PLANNED_FOR_RETIREMENT_FAMILIES
+                else Status.ACTIVE
+            )
             if not db_instance_options:
-                status = Status.INACTIVE
+                status = Status.INACTIVE if status == Status.ACTIVE else Status.RETIRED
             deployment_options = deployment_options_by_database.get(
                 database_id, frozenset()
             )

--- a/src/sc_crawler/vendors/_aws.py
+++ b/src/sc_crawler/vendors/_aws.py
@@ -222,18 +222,6 @@ _instance_suffixes = {
     "flex": "Flex instance",
 }
 
-# RDS instance classes with an announced end-of-support schedule.
-# https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.DBInstanceClass.Types.html
-_RDS_END_OF_SUPPORT_FAMILIES = frozenset(
-    {
-        "db.m3",
-        "db.m4",
-        "db.r3",
-        "db.r4",
-        "db.t2",
-    }
-)
-
 
 def _annotate_instance_type(instance_type_id):
     """Resolve instance type coding to human-friendly description.
@@ -961,7 +949,11 @@ def inventory_zones(vendor):
 
 
 def inventory_servers(vendor):
-    """List all available AWS instance types in all regions via `boto3` calls."""
+    """List all available AWS instance types in all regions via `boto3` calls.
+
+    Lifecycle (`DescribeInstanceTypeOfferings`): not offered in any active
+    region/zone -> INACTIVE. No type-level EC2 retirement API exists.
+    """
     # TODO consider dropping this in favor of pricing.get_products, as
     #      it has info e.g. on instanceFamily although other fields
     #      are messier (e.g. extract memory from string)
@@ -1589,7 +1581,11 @@ def _get_rds_instance_products_by_region() -> tuple[
 
 
 def inventory_databases(vendor):
-    """List all available AWS RDS PostgreSQL instance types via `boto3` calls."""
+    """List all available AWS RDS PostgreSQL instance types via `boto3` calls.
+
+    Lifecycle (`DescribeOrderableDBInstanceOptions`): no orderable options ->
+    RETIRED; otherwise ACTIVE.
+    """
     vendor.progress_tracker.start_task(name="Searching for database(s)", total=None)
     prices_by_region, deployment_options_by_database = (
         _get_rds_instance_products_by_region()
@@ -1615,8 +1611,6 @@ def inventory_databases(vendor):
             db_instance_options = options_by_database.get(database_id, [])
             if not db_instance_options:
                 status = Status.RETIRED
-            elif ".".join(database_id.split(".")[:2]) in _RDS_END_OF_SUPPORT_FAMILIES:
-                status = Status.PLANNED_FOR_RETIREMENT
             else:
                 status = Status.ACTIVE
             deployment_options = deployment_options_by_database.get(

--- a/src/sc_crawler/vendors/_azure.py
+++ b/src/sc_crawler/vendors/_azure.py
@@ -305,11 +305,22 @@ STORAGE_PRICE_UNIT_MAPPING: dict[str, float | None] = {
 # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retired-sizes-list
 # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/previous-gen-sizes-list
 # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/d-ds-dv2-dsv2-ls-series-migration-guide
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/nvv4-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/hbv2-series-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/hc-series-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/dcsv2-series-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/n-series-migration
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/av1-series-retirement
 # Rule format: (compiled regex or exact size, retired_on date or None).
 # - If retired_on is set and as_of >= retired_on -> RETIRED.
 # - Else matched -> PLANNED_FOR_RETIREMENT.
 # - No match -> ACTIVE.
 _AZURE_SKU_LIFECYCLE_RULES = (
+    (recompile(r"^A\d+$", IGNORECASE), date(2024, 8, 31)),  # noqa: E501  # Av1-series (Basic/Standard)
+    (recompile(r"^NC\d+r?$", IGNORECASE), date(2023, 8, 31)),  # NC v1-series
+    (recompile(r"^NC\d+r?s_v2$", IGNORECASE), date(2023, 8, 31)),  # NCv2-series
+    (recompile(r"^ND\d+r?s?$", IGNORECASE), date(2023, 8, 31)),  # ND v1-series
+    (recompile(r"^DC\d+s?_v2$", IGNORECASE), date(2026, 6, 30)),  # DCsv2-series
     (recompile(r"^NC(?:6s|12s|24s|24rs)_v3$", IGNORECASE), date(2025, 9, 30)),  # noqa: E501  # NCv3-series
     (recompile(r"^D\d+(-\d+)?$", IGNORECASE), date(2028, 5, 1)),  # D-series
     (recompile(r"^DS\d+(-\d+)?$", IGNORECASE), date(2028, 5, 1)),  # Ds-series
@@ -326,10 +337,11 @@ _AZURE_SKU_LIFECYCLE_RULES = (
     (recompile(r"^GS\d+(-\d+)?$", IGNORECASE), date(2028, 11, 15)),  # Gs-series
     (recompile(r"^L\d+s_v2$", IGNORECASE), date(2028, 11, 15)),  # Lsv2-series
     (recompile(r"^NV\d+s_v3$", IGNORECASE), date(2026, 9, 30)),  # NVv3-series
-    (recompile(r"^NV\d+as_v4$", IGNORECASE), None),  # NVv4-series (no date yet)
+    (recompile(r"^NV\d+a[h]?s_v4$", IGNORECASE), date(2026, 9, 30)),  # NVv4-series
     (recompile(r"^NP\d+s$", IGNORECASE), date(2027, 5, 31)),  # NP-series
-    (recompile(r"^HB120rs?_v2$", IGNORECASE), date(2027, 5, 31)),  # HBv2-series
-    (recompile(r"^M192i(?:d?m)?s_v2$", IGNORECASE), date(2027, 3, 31)),  # noqa: E501  # Mv2 isolated sizes
+    (recompile(r"^HC44(-\d+)?rs$", IGNORECASE), date(2027, 5, 31)),  # HC-series
+    (recompile(r"^HB120(-\d+)?rs_v2$", IGNORECASE), date(2027, 5, 31)),  # HBv2-series
+    (recompile(r"^M192i(?:dm?|m)?s_v2$", IGNORECASE), date(2027, 3, 31)),  # noqa: E501  # Mv2 isolated sizes
 )
 
 
@@ -1273,9 +1285,10 @@ def inventory_zones(vendor):
 def inventory_servers(vendor):
     """List all available instance types in all regions.
 
-    Lifecycle: `_azure_sku_lifecycle_status` maps `_AZURE_RETIRED_SKU_PATTERNS`
-    and `_AZURE_ANNOUNCED_SKU_PATTERNS`/sizes to RETIRED / PLANNED_FOR_RETIREMENT;
-    otherwise ACTIVE. Same function is used for database SKUs.
+    Lifecycle: `_azure_sku_lifecycle_status` checks `_AZURE_SKU_LIFECYCLE_RULES`
+    — RETIRED if the retirement date has passed, PLANNED_FOR_RETIREMENT if
+    matched but not yet retired, otherwise ACTIVE. Same function is used for
+    database SKUs.
     """
     servers = _servers()
     for i in range(len(servers) - 1, -1, -1):

--- a/src/sc_crawler/vendors/_azure.py
+++ b/src/sc_crawler/vendors/_azure.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from datetime import UTC, datetime
 from functools import cache
 from os import environ
+from re import IGNORECASE
 from re import compile as recompile
 from time import sleep
 from types import SimpleNamespace
@@ -32,6 +33,7 @@ from ..table_fields import (
     Disk,
     PriceTier,
     PriceUnit,
+    Status,
     StorageType,
     TrafficDirection,
 )
@@ -298,6 +300,53 @@ STORAGE_PRICE_UNIT_MAPPING: dict[str, float | None] = {
     "1 GB/Hour": _HOURS_PER_MONTH,
 }
 """Storage capacity units → multiplier to convert the raw API price to $/GB/month."""
+
+# VM size series retirement. Previous-gen is not retirement.
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retired-sizes-list
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/previous-gen-sizes-list
+_AZURE_RETIRED_SKU_PATTERNS = (
+    # NCv3-series and NCv3-NC24rs. Retired 2025-09-30.
+    recompile(r"^NC(?:6s|12s|24s|24rs)_v3$", IGNORECASE),
+)
+_AZURE_ANNOUNCED_SKU_SIZES = frozenset(
+    {
+        "m192idms_v2",
+        "m192ids_v2",
+        "m192ims_v2",
+        "m192is_v2",
+    }
+)
+_AZURE_ANNOUNCED_SKU_PATTERNS = (
+    recompile(r"^D\d+(-\d+)?$", IGNORECASE),  # D-series
+    recompile(r"^DS\d+(-\d+)?$", IGNORECASE),  # Ds-series
+    recompile(r"^D\d+(-\d+)?_v2$", IGNORECASE),  # Dv2-series
+    recompile(r"^DS\d+(-\d+)?_v2$", IGNORECASE),  # Dsv2-series
+    recompile(r"^A\d+_v2$", IGNORECASE),  # Av2-series
+    recompile(r"^A\d+m_v2$", IGNORECASE),  # Amv2-series
+    recompile(r"^B\d+[a-z]*$", IGNORECASE),  # B-series (V1), not Bv2
+    recompile(r"^F\d+$", IGNORECASE),  # F-series
+    recompile(r"^F\d+s$", IGNORECASE),  # Fs-series
+    recompile(r"^F\d+s_v2$", IGNORECASE),  # Fsv2-series
+    recompile(r"^G\d+$", IGNORECASE),  # G-series
+    recompile(r"^GS\d+(-\d+)?$", IGNORECASE),  # Gs-series
+    recompile(r"^L\d+s$", IGNORECASE),  # Ls-series
+    recompile(r"^L\d+s_v2$", IGNORECASE),  # Lsv2-series
+    recompile(r"^NV\d+s_v3$", IGNORECASE),  # NVv3-series
+    recompile(r"^NV\d+as_v4$", IGNORECASE),  # NVv4-series
+    recompile(r"^NP\d+s$", IGNORECASE),  # NP-series
+)
+
+
+def _azure_sku_lifecycle_status(sku_name: str) -> Status:
+    """Map an Azure VM / Flexible Server SKU name to Server/Database status."""
+    size = sku_name.removeprefix("Standard_").removeprefix("Basic_")
+    if size.lower() in _AZURE_ANNOUNCED_SKU_SIZES:
+        return Status.PLANNED_FOR_RETIREMENT
+    if any(pattern.fullmatch(size) for pattern in _AZURE_RETIRED_SKU_PATTERNS):
+        return Status.RETIRED
+    if any(pattern.fullmatch(size) for pattern in _AZURE_ANNOUNCED_SKU_PATTERNS):
+        return Status.PLANNED_FOR_RETIREMENT
+    return Status.ACTIVE
 
 
 def _parse_server_name(name):
@@ -580,6 +629,7 @@ def _standardize_server(server: dict, vendor) -> dict:
         "inbound_traffic": 0,
         "outbound_traffic": 0,
         "ipv4": 0,
+        "status": _azure_sku_lifecycle_status(server["name"]),
     }
 
 
@@ -1934,6 +1984,7 @@ def inventory_databases(vendor):
                             # Product max PITR retention (days); default 7, up to 35; not in capabilities API.
                             "continuous_backups": 35,
                             "sla": sla,
+                            "status": _azure_sku_lifecycle_status(database_id),
                         }
         vendor.progress_tracker.advance_task()
     vendor.progress_tracker.hide_task()

--- a/src/sc_crawler/vendors/_azure.py
+++ b/src/sc_crawler/vendors/_azure.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from functools import cache
 from os import environ
 from re import IGNORECASE
@@ -301,50 +301,48 @@ STORAGE_PRICE_UNIT_MAPPING: dict[str, float | None] = {
 }
 """Storage capacity units → multiplier to convert the raw API price to $/GB/month."""
 
-# VM size series retirement. Previous-gen is not retirement.
+# VM size series lifecycle. Previous-gen is not retirement.
 # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retired-sizes-list
 # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/previous-gen-sizes-list
-_AZURE_RETIRED_SKU_PATTERNS = (
-    # NCv3-series and NCv3-NC24rs. Retired 2025-09-30.
-    recompile(r"^NC(?:6s|12s|24s|24rs)_v3$", IGNORECASE),
-)
-_AZURE_ANNOUNCED_SKU_SIZES = frozenset(
-    {
-        "m192idms_v2",
-        "m192ids_v2",
-        "m192ims_v2",
-        "m192is_v2",
-    }
-)
-_AZURE_ANNOUNCED_SKU_PATTERNS = (
-    recompile(r"^D\d+(-\d+)?$", IGNORECASE),  # D-series
-    recompile(r"^DS\d+(-\d+)?$", IGNORECASE),  # Ds-series
-    recompile(r"^D\d+(-\d+)?_v2$", IGNORECASE),  # Dv2-series
-    recompile(r"^DS\d+(-\d+)?_v2$", IGNORECASE),  # Dsv2-series
-    recompile(r"^A\d+_v2$", IGNORECASE),  # Av2-series
-    recompile(r"^A\d+m_v2$", IGNORECASE),  # Amv2-series
-    recompile(r"^B\d+[a-z]*$", IGNORECASE),  # B-series (V1), not Bv2
-    recompile(r"^F\d+$", IGNORECASE),  # F-series
-    recompile(r"^F\d+s$", IGNORECASE),  # Fs-series
-    recompile(r"^F\d+s_v2$", IGNORECASE),  # Fsv2-series
-    recompile(r"^G\d+$", IGNORECASE),  # G-series
-    recompile(r"^GS\d+(-\d+)?$", IGNORECASE),  # Gs-series
-    recompile(r"^L\d+s$", IGNORECASE),  # Ls-series
-    recompile(r"^L\d+s_v2$", IGNORECASE),  # Lsv2-series
-    recompile(r"^NV\d+s_v3$", IGNORECASE),  # NVv3-series
-    recompile(r"^NV\d+as_v4$", IGNORECASE),  # NVv4-series
-    recompile(r"^NP\d+s$", IGNORECASE),  # NP-series
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/d-ds-dv2-dsv2-ls-series-migration-guide
+# Rule format: (compiled regex or exact size, retired_on date or None).
+# - If retired_on is set and as_of >= retired_on -> RETIRED.
+# - Else matched -> PLANNED_FOR_RETIREMENT.
+# - No match -> ACTIVE.
+_AZURE_SKU_LIFECYCLE_RULES = (
+    (recompile(r"^NC(?:6s|12s|24s|24rs)_v3$", IGNORECASE), date(2025, 9, 30)),  # noqa: E501  # NCv3-series
+    (recompile(r"^D\d+(-\d+)?$", IGNORECASE), date(2028, 5, 1)),  # D-series
+    (recompile(r"^DS\d+(-\d+)?$", IGNORECASE), date(2028, 5, 1)),  # Ds-series
+    (recompile(r"^D\d+(-\d+)?_v2$", IGNORECASE), date(2028, 5, 1)),  # Dv2-series
+    (recompile(r"^DS\d+(-\d+)?_v2$", IGNORECASE), date(2028, 5, 1)),  # Dsv2-series
+    (recompile(r"^L\d+s$", IGNORECASE), date(2028, 5, 1)),  # Ls-series
+    (recompile(r"^A\d+_v2$", IGNORECASE), date(2028, 11, 15)),  # Av2-series
+    (recompile(r"^A\d+m_v2$", IGNORECASE), date(2028, 11, 15)),  # Amv2-series
+    (recompile(r"^B\d+[a-z]*$", IGNORECASE), date(2028, 11, 15)),  # Bv1-series, not Bv2
+    (recompile(r"^F\d+$", IGNORECASE), date(2028, 11, 15)),  # F-series
+    (recompile(r"^F\d+s$", IGNORECASE), date(2028, 11, 15)),  # Fs-series
+    (recompile(r"^F\d+s_v2$", IGNORECASE), date(2028, 11, 15)),  # Fsv2-series
+    (recompile(r"^G\d+$", IGNORECASE), date(2028, 11, 15)),  # G-series
+    (recompile(r"^GS\d+(-\d+)?$", IGNORECASE), date(2028, 11, 15)),  # Gs-series
+    (recompile(r"^L\d+s_v2$", IGNORECASE), date(2028, 11, 15)),  # Lsv2-series
+    (recompile(r"^NV\d+s_v3$", IGNORECASE), date(2026, 9, 30)),  # NVv3-series
+    (recompile(r"^NV\d+as_v4$", IGNORECASE), None),  # NVv4-series (no date yet)
+    (recompile(r"^NP\d+s$", IGNORECASE), date(2027, 5, 31)),  # NP-series
+    (recompile(r"^HB120rs?_v2$", IGNORECASE), date(2027, 5, 31)),  # HBv2-series
+    (recompile(r"^M192i(?:d?m)?s_v2$", IGNORECASE), date(2027, 3, 31)),  # noqa: E501  # Mv2 isolated sizes
 )
 
 
-def _azure_sku_lifecycle_status(sku_name: str) -> Status:
+def _azure_sku_lifecycle_status(sku_name: str, as_of: date | None = None) -> Status:
     """Map an Azure VM / Flexible Server SKU name to Server/Database status."""
+    current_date = as_of or datetime.now(UTC).date()
     size = sku_name.removeprefix("Standard_").removeprefix("Basic_")
-    if size.lower() in _AZURE_ANNOUNCED_SKU_SIZES:
-        return Status.PLANNED_FOR_RETIREMENT
-    if any(pattern.fullmatch(size) for pattern in _AZURE_RETIRED_SKU_PATTERNS):
-        return Status.RETIRED
-    if any(pattern.fullmatch(size) for pattern in _AZURE_ANNOUNCED_SKU_PATTERNS):
+
+    for pattern, retired_on in _AZURE_SKU_LIFECYCLE_RULES:
+        if not pattern.fullmatch(size):
+            continue
+        if retired_on and current_date >= retired_on:
+            return Status.RETIRED
         return Status.PLANNED_FOR_RETIREMENT
     return Status.ACTIVE
 
@@ -1273,7 +1271,12 @@ def inventory_zones(vendor):
 
 
 def inventory_servers(vendor):
-    """List all available instance types in all regions."""
+    """List all available instance types in all regions.
+
+    Lifecycle: `_azure_sku_lifecycle_status` maps `_AZURE_RETIRED_SKU_PATTERNS`
+    and `_AZURE_ANNOUNCED_SKU_PATTERNS`/sizes to RETIRED / PLANNED_FOR_RETIREMENT;
+    otherwise ACTIVE. Same function is used for database SKUs.
+    """
     servers = _servers()
     for i in range(len(servers) - 1, -1, -1):
         name = servers[i].get("name")

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -903,7 +903,12 @@ def inventory_zones(vendor):
 
 
 def inventory_servers(vendor):
-    """List all available GCP servers available in all zones."""
+    """List all available GCP servers available in all zones.
+
+    Lifecycle (`machineTypes.deprecated.state`): DEPRECATED -> PLANNED_FOR_RETIREMENT,
+    OBSOLETE / DELETED -> RETIRED, empty / ACTIVE -> ACTIVE.
+    See `_gcp_machine_type_status`.
+    """
     servers = parallel_fetch_servers(vendor, _search_servers, "name", "zones")
     servers = preprocess_servers(servers, vendor, add_vendor_id)
     return servers

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -153,6 +153,23 @@ STORAGE_DESCRIPTION_TO_FAMILY = {
 # partial list of storages to exclude options with extra pricing on IOPS/throughput
 STORAGE_ALLOWLIST = ["pd-standard", "pd-ssd", "pd-balanced"]
 
+# Compute Engine machineTypes.deprecated.state.
+# https://cloud.google.com/compute/docs/reference/rest/v1/machineTypes
+# DEPRECATED: still creatable, with a replacement warning.
+# OBSOLETE / DELETED: create is rejected.
+_GCP_DEPRECATION_STATE_TO_STATUS = {
+    "": Status.ACTIVE,
+    "ACTIVE": Status.ACTIVE,
+    "DEPRECATED": Status.PLANNED_FOR_RETIREMENT,
+    "OBSOLETE": Status.RETIRED,
+    "DELETED": Status.RETIRED,
+}
+
+
+def _gcp_machine_type_status(deprecated_state: str | None) -> Status:
+    """Map Compute Engine DeprecationStatus.state to Server/Database status."""
+    return _GCP_DEPRECATION_STATE_TO_STATUS.get(deprecated_state or "", Status.ACTIVE)
+
 
 def _server_family(server_name: str) -> str:
     """Look up server family based on server name to build the SKU lookup key."""
@@ -322,9 +339,7 @@ def _search_servers(zone_name: str) -> List[dict]:
                 "inbound_traffic": 0,
                 "outbound_traffic": 0,
                 "ipv4": 0,
-                "status": (
-                    Status.ACTIVE if server.deprecated.state == "" else Status.INACTIVE
-                ),
+                "status": _gcp_machine_type_status(server.deprecated.state),
             }
         )
     return zone_servers
@@ -1331,14 +1346,16 @@ def inventory_databases(vendor):
         description = f"PostgreSQL Cloud SQL {family_label}"
         if spec_parts:
             description = f"{description} ({', '.join(spec_parts)})"
-        server_id = next(
+        server = next(
             (
-                server.server_id
-                for server in vendor.servers
-                if server.api_reference == tier_name.removeprefix("db-")
+                item
+                for item in vendor.servers
+                if item.api_reference == tier_name.removeprefix("db-")
             ),
             None,
         )
+        server_id = server.server_id if server is not None else None
+        status = server.status if server is not None else Status.ACTIVE
         raw_regions = tier.get("region")
         if isinstance(raw_regions, str):
             tier_regions = [raw_regions]
@@ -1463,6 +1480,7 @@ def inventory_databases(vendor):
                         else None
                     )
                 ),
+                "status": status,
             }
         )
         vendor.progress_tracker.advance_task()

--- a/src/sc_crawler/vendors/_hcloud.py
+++ b/src/sc_crawler/vendors/_hcloud.py
@@ -210,7 +210,13 @@ def inventory_zones(vendor):
 def inventory_servers(vendor):
     """List all server types from API and manual data entry from the Hetzner Cloud homepage.
 
-    CPU information is recorded from <https://www.hetzner.com/cloud/> as not exposed via API."""
+    CPU information is recorded from <https://www.hetzner.com/cloud/> as not exposed via API.
+
+    Lifecycle (per-location server type fields): `deprecation.unavailable_after` in
+    past -> RETIRED, `deprecation` present -> PLANNED_FOR_RETIREMENT,
+    `available is False` or empty locations -> INACTIVE, otherwise ACTIVE.
+    See `_hcloud_server_status`.
+    """
     now = datetime.now(UTC)
     items = []
     for server in _client().server_types.get_all():

--- a/src/sc_crawler/vendors/_hcloud.py
+++ b/src/sc_crawler/vendors/_hcloud.py
@@ -1,4 +1,5 @@
 import os
+from datetime import UTC, datetime
 from functools import cache
 
 from hcloud import Client
@@ -68,6 +69,34 @@ def _server_cpu(server_name):
     if server_name.upper() in ["CCX13", "CCX23", "CCX33", "CCX43", "CCX53", "CCX63"]:
         return ("AMD", None, None)
     raise ValueError("Unknown Hetzner Cloud server name: " + server_name)
+
+
+# https://docs.hetzner.cloud/reference/cloud#tag/server-types/list_server_types
+# https://docs.hetzner.cloud/changelog#2025-09-24-per-location-server-types
+def _hcloud_location_status(location, now: datetime) -> Status:
+    if location is None:
+        return Status.INACTIVE
+    deprecation = location.deprecation
+    if deprecation is not None:
+        unavailable_after = deprecation.unavailable_after
+        if unavailable_after is not None:
+            if unavailable_after.tzinfo is None:
+                unavailable_after = unavailable_after.replace(tzinfo=UTC)
+            if unavailable_after <= now:
+                return Status.RETIRED
+        return Status.PLANNED_FOR_RETIREMENT
+    if location.available is False:
+        return Status.INACTIVE
+    return Status.ACTIVE
+
+
+def _hcloud_server_status(server, now: datetime) -> Status:
+    """Map Hetzner per-location support/deprecation to a single Server status."""
+    if not server.locations:
+        return Status.INACTIVE
+    return Status.best(
+        {_hcloud_location_status(location, now) for location in server.locations}
+    )
 
 
 # ##############################################################################
@@ -244,9 +273,7 @@ def inventory_servers(vendor):
                         / (1024**3)
                     ),
                     "ipv4": 0,
-                    "status": Status.ACTIVE
-                    if not server.deprecation
-                    else Status.INACTIVE,
+                    "status": _hcloud_server_status(server),
                 }
             )
     return items
@@ -254,8 +281,16 @@ def inventory_servers(vendor):
 
 def inventory_server_prices(vendor):
     regions = scmodels_to_dict(vendor.regions, keys=["name", "aliases"])
+    now = datetime.now(UTC)
     items = []
     for server in _client().server_types.get_all():
+        locations_by_name = {}
+        if server.locations:
+            locations_by_name = {
+                loc.location.name: loc
+                for loc in server.locations
+                if loc.location is not None
+            }
         for location in server.prices:
             region_id = regions[location["location"]].region_id
             hourly_price = float(location["price_hourly"]["net"])
@@ -264,6 +299,9 @@ def inventory_server_prices(vendor):
             # we need to proxy the number of discounted hours in a month
             # (rounding to full hours is a good-enough approximation)
             monthly_cap = int(float(location["price_monthly"]["net"]) / hourly_price)
+            loc = locations_by_name.get(location["location"])
+            status = _hcloud_location_status(loc, now)
+            price_status = Status.ACTIVE if status.is_orderable else Status.INACTIVE
             items.append(
                 {
                     "vendor_id": vendor.vendor_id,
@@ -281,6 +319,7 @@ def inventory_server_prices(vendor):
                         {"lower": monthly_cap + 1, "upper": "Infinity", "price": 0},
                     ],
                     "currency": "EUR",
+                    "status": price_status,
                 }
             )
     return items

--- a/src/sc_crawler/vendors/_hcloud.py
+++ b/src/sc_crawler/vendors/_hcloud.py
@@ -211,6 +211,7 @@ def inventory_servers(vendor):
     """List all server types from API and manual data entry from the Hetzner Cloud homepage.
 
     CPU information is recorded from <https://www.hetzner.com/cloud/> as not exposed via API."""
+    now = datetime.now(UTC)
     items = []
     for server in _client().server_types.get_all():
         # CPU info not available via the API,
@@ -273,7 +274,7 @@ def inventory_servers(vendor):
                         / (1024**3)
                     ),
                     "ipv4": 0,
-                    "status": _hcloud_server_status(server),
+                    "status": _hcloud_server_status(server, now),
                 }
             )
     return items

--- a/src/sc_crawler/vendors/_ovh.py
+++ b/src/sc_crawler/vendors/_ovh.py
@@ -578,7 +578,11 @@ def inventory_zones(vendor) -> list[dict]:
 
 
 def inventory_servers(vendor) -> list[dict]:
-    """List all server types (called "flavors" at OVHcloud)."""
+    """List all server types (called "flavors" at OVHcloud).
+
+    Lifecycle (catalog plan `blobs.tags`): `active` tag -> ACTIVE, otherwise
+    INACTIVE. The `legacy` tag is not treated as retirement.
+    """
     items = []
 
     server_plans = [

--- a/src/sc_crawler/vendors/_ovh.py
+++ b/src/sc_crawler/vendors/_ovh.py
@@ -672,8 +672,6 @@ def inventory_servers(vendor) -> list[dict]:
             disk.size for disk in storages if disk.storage_type == StorageType.SSD
         )
 
-        status = Status.ACTIVE if "active" in blobs.get("tags", []) else Status.INACTIVE
-
         description_parts = [
             f"{vcpus} vCPUs",
             f"{memory_size_gb} GiB RAM",
@@ -741,7 +739,11 @@ def inventory_servers(vendor) -> list[dict]:
                 "inbound_traffic": 0,
                 "outbound_traffic": 0,
                 "ipv4": 1,  # each instance gets one IPv4
-                "status": status,
+                "status": (
+                    Status.ACTIVE
+                    if "active" in (blobs.get("tags") or [])
+                    else Status.INACTIVE
+                ),
             }
         )
 

--- a/src/sc_crawler/vendors/_upcloud.py
+++ b/src/sc_crawler/vendors/_upcloud.py
@@ -124,28 +124,16 @@ def _parse_server_name(name):
     return data
 
 
-# No longer orderable for new deployments as of 2026-04-16.
-# https://upcloud.com/global/blog/introducing-starter-and-premium-plans/
-_UPCLOUD_RETIRED_FAMILIES = frozenset(
-    {
-        "Developer",
-        "General Purpose",
-        "High CPU",
-        "High Memory",
-    }
-)
-
-
-def _upcloud_server_status(vendor, server_name: str, family: str) -> Status:
-    """Map UpCloud plan family and GPU stock to Server status."""
-    if family in _UPCLOUD_RETIRED_FAMILIES:
+def _upcloud_server_status(vendor, server: dict) -> Status:
+    """Map plan current_offering and GPU stock to Server status."""
+    if server.get("current_offering") == "no":
         return Status.RETIRED
-    if family != "GPU":
+    if server.get("family") != "gpu":
         return Status.ACTIVE
     for region in vendor.regions:
         amount = (
             _get_gpu_region_availability(region.region_id)
-            .get(server_name, {})
+            .get(server["name"], {})
             .get("amount", 0)
         )
         if amount:
@@ -468,9 +456,7 @@ def inventory_servers(vendor):
                     "inbound_traffic": 0,
                     "outbound_traffic": server["public_traffic_out"],
                     "ipv4": 0 if server_data["family"] == "CLOUDNATIVE" else 1,
-                    "status": _upcloud_server_status(
-                        vendor, server["name"], server_data["family"]
-                    ),
+                    "status": _upcloud_server_status(vendor, server),
                 }
             )
     return items

--- a/src/sc_crawler/vendors/_upcloud.py
+++ b/src/sc_crawler/vendors/_upcloud.py
@@ -404,6 +404,12 @@ def inventory_zones(vendor):
 
 
 def inventory_servers(vendor):
+    """List all server plans from UpCloud API.
+
+    Lifecycle: `current_offering == "no"` -> RETIRED; GPU plans with zero stock
+    in `/device/availability` across all regions -> INACTIVE; otherwise ACTIVE.
+    See `_upcloud_server_status`.
+    """
     servers = _client().get_server_plans()["plans"]["plan"]
     items = []
     for server in servers:

--- a/src/sc_crawler/vendors/_upcloud.py
+++ b/src/sc_crawler/vendors/_upcloud.py
@@ -13,6 +13,7 @@ from ..table_fields import (
     CpuAllocation,
     CpuArchitecture,
     PriceUnit,
+    Status,
     StorageType,
     TrafficDirection,
 )
@@ -121,6 +122,35 @@ def _parse_server_name(name):
         description_parts.append(f"{data['gpu_count']}x {data['gpu_model']}")
     data["description"] = f"{data['family']} ({', '.join(description_parts)})"
     return data
+
+
+# No longer orderable for new deployments as of 2026-04-16.
+# https://upcloud.com/global/blog/introducing-starter-and-premium-plans/
+_UPCLOUD_RETIRED_FAMILIES = frozenset(
+    {
+        "Developer",
+        "General Purpose",
+        "High CPU",
+        "High Memory",
+    }
+)
+
+
+def _upcloud_server_status(vendor, server_name: str, family: str) -> Status:
+    """Map UpCloud plan family and GPU stock to Server status."""
+    if family in _UPCLOUD_RETIRED_FAMILIES:
+        return Status.RETIRED
+    if family != "GPU":
+        return Status.ACTIVE
+    for region in vendor.regions:
+        amount = (
+            _get_gpu_region_availability(region.region_id)
+            .get(server_name, {})
+            .get("amount", 0)
+        )
+        if amount:
+            return Status.ACTIVE
+    return Status.INACTIVE
 
 
 _UPCLOUD_GPU_MEMORY_MIB = {
@@ -438,6 +468,9 @@ def inventory_servers(vendor):
                     "inbound_traffic": 0,
                     "outbound_traffic": server["public_traffic_out"],
                     "ipv4": 0 if server_data["family"] == "CLOUDNATIVE" else 1,
+                    "status": _upcloud_server_status(
+                        vendor, server["name"], server_data["family"]
+                    ),
                 }
             )
     return items

--- a/src/sc_crawler/vendors/_vultr.py
+++ b/src/sc_crawler/vendors/_vultr.py
@@ -390,7 +390,10 @@ def inventory_zones(vendor):
 
 
 def inventory_servers(vendor):
-    """List all servers from Vultr API."""
+    """List all servers from Vultr API.
+
+    Lifecycle: free plan or empty `locations` -> INACTIVE, otherwise ACTIVE.
+    """
     plans = _get_plans()
     plans_metal = _get_plans_metal()
 

--- a/src/sc_crawler/vendors/_vultr.py
+++ b/src/sc_crawler/vendors/_vultr.py
@@ -544,8 +544,10 @@ def inventory_servers(vendor):
         }
 
         # exclude limited plans not generally available without scale
-        if item["server_id"] == "vc2-1c-0.5gb-free":
+        if item["server_id"] == "vc2-1c-0.5gb-free" or not server.get("locations"):
             item["status"] = Status.INACTIVE
+        else:
+            item["status"] = Status.ACTIVE
 
         items.append(item)
     return items

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -31,6 +31,9 @@ from sc_crawler.vendors._aws import (
 from sc_crawler.vendors._aws import (
     inventory_databases as aws_databases,
 )
+from sc_crawler.vendors._aws import (
+    inventory_server_prices as aws_server_prices,
+)
 from sc_crawler.vendors._azure import (
     _pg_database_regions,
     _pg_engine_versions,
@@ -1513,7 +1516,7 @@ def test_aws_inventory_databases_dedupes_across_regions():
     assert [row["database_id"] for row in rows] == ["db.m5.large"]
 
 
-def test_aws_inventory_databases_marks_status_from_generation_and_options():
+def test_aws_inventory_databases_status_from_orderable_options_and_end_of_support():
     vendor = _aws_vendor(
         regions=[Mock(region_id="us-east-1", status=Status.ACTIVE)],
     )
@@ -1543,6 +1546,12 @@ def test_aws_inventory_databases_marks_status_from_generation_and_options():
                 "memory": "1 GiB",
                 "storage": "EBS Only",
             },
+            "db.t1.micro": {
+                "instanceFamily": "General purpose",
+                "vcpu": "1",
+                "memory": "1 GiB",
+                "storage": "EBS Only",
+            },
         }
     }
     orderable = {
@@ -1565,6 +1574,7 @@ def test_aws_inventory_databases_marks_status_from_generation_and_options():
                     "db.m4.large": frozenset({"Single-AZ", "Multi-AZ"}),
                     "db.m6g.large": frozenset({"Single-AZ", "Multi-AZ"}),
                     "db.t2.micro": frozenset({"Single-AZ", "Multi-AZ"}),
+                    "db.t1.micro": frozenset({"Single-AZ", "Multi-AZ"}),
                 },
             ),
         ),
@@ -1579,15 +1589,76 @@ def test_aws_inventory_databases_marks_status_from_generation_and_options():
                 "db.m4.large": [orderable],
                 "db.m6g.large": [],
                 "db.t2.micro": [],
+                "db.t1.micro": [],
             },
         ),
     ):
         rows = aws_databases(vendor)
     by_id = {row["database_id"]: row for row in rows}
     assert by_id["db.m5.large"]["status"] == Status.ACTIVE
+    # orderable, but with an announced end-of-support date
     assert by_id["db.m4.large"]["status"] == Status.PLANNED_FOR_RETIREMENT
-    assert by_id["db.m6g.large"]["status"] == Status.INACTIVE
+    assert by_id["db.m6g.large"]["status"] == Status.RETIRED
+    # not orderable wins over the end-of-support mapping
     assert by_id["db.t2.micro"]["status"] == Status.RETIRED
+    # not orderable classes are retired without being mapped
+    assert by_id["db.t1.micro"]["status"] == Status.RETIRED
+
+
+def test_aws_inventory_server_prices_deactivates_unoffered_instance_types():
+    region = Mock(
+        region_id="us-east-1",
+        api_reference="us-east-1",
+        aliases=[],
+        status=Status.ACTIVE,
+    )
+    region.name = "US East (N. Virginia)"
+    m5 = Mock(server_id="m5.large", status=Status.ACTIVE)
+    t1 = Mock(server_id="t1.micro", status=Status.ACTIVE)
+    mac = Mock(server_id="mac1.metal", status=Status.ACTIVE)
+    vendor = _aws_vendor(regions=[region], servers=[m5, t1, mac])
+    products = [
+        {
+            "product": {
+                "attributes": {
+                    "location": "US East (N. Virginia)",
+                    "instanceType": "m5.large",
+                }
+            },
+            "terms": _aws_ondemand_terms("0.096"),
+        },
+        {
+            "product": {
+                "attributes": {
+                    "location": "US East (N. Virginia)",
+                    "instanceType": "t1.micro",
+                }
+            },
+            "terms": _aws_ondemand_terms("0.02"),
+        },
+    ]
+    with (
+        patch(
+            "sc_crawler.vendors._aws._boto_get_products",
+            return_value=products,
+        ),
+        patch(
+            "sc_crawler.vendors._aws._describe_instance_type_offerings_per_zone_with_progress",
+            return_value={
+                "m5.large": ["use1-az1"],
+                "mac1.metal": ["use1-az1"],
+            },
+        ),
+    ):
+        prices = aws_server_prices(vendor)
+    assert {(p["server_id"], p["zone_id"]) for p in prices} == {
+        ("m5.large", "use1-az1")
+    }
+    assert m5.status == Status.ACTIVE
+    # still priced, but not offered in any zone
+    assert t1.status == Status.INACTIVE
+    # offered, even without a Linux on-demand SKU
+    assert mac.status == Status.ACTIVE
 
 
 def test_aws_inventory_database_prices_by_ha_deployment():

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1513,25 +1513,47 @@ def test_aws_inventory_databases_dedupes_across_regions():
     assert [row["database_id"] for row in rows] == ["db.m5.large"]
 
 
-def test_aws_inventory_databases_marks_non_orderable_classes_inactive():
+def test_aws_inventory_databases_marks_status_from_generation_and_options():
     vendor = _aws_vendor(
         regions=[Mock(region_id="us-east-1", status=Status.ACTIVE)],
     )
     prices_by_region = {
         "us-east-1": {
-            "db.t2.micro": {
-                "instanceFamily": "General purpose",
-                "vcpu": "1",
-                "memory": "1 GiB",
-                "storage": "EBS Only",
-            },
             "db.m5.large": {
                 "instanceFamily": "General purpose",
                 "vcpu": "2",
                 "memory": "8 GiB",
                 "storage": "EBS Only",
             },
+            "db.m4.large": {
+                "instanceFamily": "General purpose",
+                "vcpu": "2",
+                "memory": "8 GiB",
+                "storage": "EBS Only",
+            },
+            "db.m6g.large": {
+                "instanceFamily": "General purpose",
+                "vcpu": "2",
+                "memory": "8 GiB",
+                "storage": "EBS Only",
+            },
+            "db.t2.micro": {
+                "instanceFamily": "General purpose",
+                "vcpu": "1",
+                "memory": "1 GiB",
+                "storage": "EBS Only",
+            },
         }
+    }
+    orderable = {
+        "MultiAZCapable": True,
+        "SupportsStorageAutoscaling": True,
+        "MinStorageSize": 20,
+        "MaxStorageSize": 65536,
+        "SupportsStorageEncryption": True,
+        "SupportsEnhancedMonitoring": True,
+        "SupportsPerformanceInsights": True,
+        "ReadReplicaCapable": True,
     }
     with (
         patch(
@@ -1539,8 +1561,10 @@ def test_aws_inventory_databases_marks_non_orderable_classes_inactive():
             return_value=(
                 prices_by_region,
                 {
-                    "db.t2.micro": frozenset({"Single-AZ", "Multi-AZ"}),
                     "db.m5.large": frozenset({"Single-AZ", "Multi-AZ"}),
+                    "db.m4.large": frozenset({"Single-AZ", "Multi-AZ"}),
+                    "db.m6g.large": frozenset({"Single-AZ", "Multi-AZ"}),
+                    "db.t2.micro": frozenset({"Single-AZ", "Multi-AZ"}),
                 },
             ),
         ),
@@ -1551,27 +1575,19 @@ def test_aws_inventory_databases_marks_non_orderable_classes_inactive():
         patch(
             "sc_crawler.vendors._aws._lookup_orderable_db_instance_options",
             return_value={
+                "db.m5.large": [orderable],
+                "db.m4.large": [orderable],
+                "db.m6g.large": [],
                 "db.t2.micro": [],
-                "db.m5.large": [
-                    {
-                        "MultiAZCapable": True,
-                        "SupportsStorageAutoscaling": True,
-                        "MinStorageSize": 20,
-                        "MaxStorageSize": 65536,
-                        "SupportsStorageEncryption": True,
-                        "SupportsEnhancedMonitoring": True,
-                        "SupportsPerformanceInsights": True,
-                        "ReadReplicaCapable": True,
-                    }
-                ],
             },
         ),
     ):
         rows = aws_databases(vendor)
     by_id = {row["database_id"]: row for row in rows}
-    assert set(by_id) == {"db.t2.micro", "db.m5.large"}
-    assert by_id["db.t2.micro"]["status"] == Status.INACTIVE
     assert by_id["db.m5.large"]["status"] == Status.ACTIVE
+    assert by_id["db.m4.large"]["status"] == Status.PLANNED_FOR_RETIREMENT
+    assert by_id["db.m6g.large"]["status"] == Status.INACTIVE
+    assert by_id["db.t2.micro"]["status"] == Status.RETIRED
 
 
 def test_aws_inventory_database_prices_by_ha_deployment():

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -35,6 +35,7 @@ from sc_crawler.vendors._aws import (
     inventory_server_prices as aws_server_prices,
 )
 from sc_crawler.vendors._azure import (
+    _azure_sku_lifecycle_status,
     _pg_database_regions,
     _pg_engine_versions,
     _pg_lookup_retail_price,
@@ -49,6 +50,7 @@ from sc_crawler.vendors._azure import (
     inventory_databases as azure_databases,
 )
 from sc_crawler.vendors._gcp import (
+    _gcp_machine_type_status,
     _pg_storage_id,
     inventory_database_prices,
     inventory_databases,
@@ -304,6 +306,50 @@ def test_pg_engine_versions_from_capability():
     assert _pg_engine_versions(capability) == ["15", "16"]
 
 
+def test_azure_sku_lifecycle_status_from_retired_sizes_list():
+    # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retired-sizes-list
+    announced = [
+        "Standard_D2",
+        "Standard_DS2",
+        "Standard_D2_v2",
+        "Standard_DS2_v2",
+        "Standard_A2_v2",
+        "Standard_A2m_v2",
+        "Standard_B1ms",
+        "Standard_F2",
+        "Standard_F2s",
+        "Standard_F2s_v2",
+        "Standard_G1",
+        "Standard_GS2",
+        "Standard_L8s",
+        "Standard_L8s_v2",
+        "Standard_NV12s_v3",
+        "Standard_NV8as_v4",
+        "Standard_NP10s",
+        "Standard_M192ims_v2",
+    ]
+    retired = [
+        "Standard_NC6s_v3",
+        "Standard_NC24rs_v3",
+    ]
+    active = [
+        "Standard_D2s_v3",
+        "Standard_D4s_v5",
+        "Standard_B2als_v2",
+        "Standard_E2s_v3",
+        "Standard_L8s_v3",
+        "Standard_NC4as_T4_v3",
+        "Standard_NV4ads_V710_v5",
+        "Standard_M64s_v2",
+    ]
+    for sku in announced:
+        assert _azure_sku_lifecycle_status(sku) == Status.PLANNED_FOR_RETIREMENT, sku
+    for sku in retired:
+        assert _azure_sku_lifecycle_status(sku) == Status.RETIRED, sku
+    for sku in active:
+        assert _azure_sku_lifecycle_status(sku) == Status.ACTIVE, sku
+
+
 def test_azure_inventory_databases_autotuning_from_supported_features():
     """IndexTuning → advice; AdaptiveAutoVacuumAutoApply → apply (param auto-tune)."""
     vendor = Mock(vendor_id="azure")
@@ -486,6 +532,9 @@ def test_azure_inventory_databases_ha_from_supported_ha_mode():
         DatabaseHaStrategy.PASSIVE_STANDBY,
         DatabaseHaStrategy.NONE,
     ]
+    assert by_id["Standard_B1ms"]["status"] == Status.PLANNED_FOR_RETIREMENT
+    assert by_id["Standard_D2s_v3"]["status"] == Status.ACTIVE
+    assert by_id["Standard_E2s_v3"]["status"] == Status.ACTIVE
 
 
 def test_azure_inventory_database_prices_emit_ha_rows():
@@ -605,6 +654,62 @@ def test_azure_inventory_database_prices_emit_ha_rows():
         ]
         == 0.29
     )
+
+
+def test_gcp_machine_type_status_from_deprecation_state():
+    # https://cloud.google.com/compute/docs/reference/rest/v1/machineTypes
+    assert _gcp_machine_type_status("") == Status.ACTIVE
+    assert _gcp_machine_type_status("ACTIVE") == Status.ACTIVE
+    assert _gcp_machine_type_status(None) == Status.ACTIVE
+    assert _gcp_machine_type_status("DEPRECATED") == Status.PLANNED_FOR_RETIREMENT
+    assert _gcp_machine_type_status("OBSOLETE") == Status.RETIRED
+    assert _gcp_machine_type_status("DELETED") == Status.RETIRED
+
+
+def test_gcp_inventory_databases_inherits_gce_machine_type_status():
+    vendor = Mock(vendor_id="gcp")
+    vendor.regions = []
+    vendor.servers = [
+        Mock(
+            server_id="n1-standard-4",
+            api_reference="n1-standard-4",
+            status=Status.PLANNED_FOR_RETIREMENT,
+        )
+    ]
+    vendor.progress_tracker = Mock(
+        start_task=Mock(), advance_task=Mock(), hide_task=Mock()
+    )
+    with (
+        patch(
+            "sc_crawler.vendors._gcp._pg_sqladmin_metadata",
+            return_value={
+                "tiers": [
+                    {
+                        "tier": "db-n1-standard-4",
+                        "RAM": "16106127360",
+                        "region": ["us-central1"],
+                    },
+                    {
+                        "tier": "db-perf-optimized-N-4",
+                        "RAM": "17179869184",
+                        "region": ["us-central1"],
+                    },
+                ],
+                "engine_versions": ["16"],
+                "custom_config": True,
+                "custom_extensions": True,
+            },
+        ),
+        patch(
+            "sc_crawler.vendors._gcp._pg_billing_catalog",
+            return_value=({}, frozenset()),
+        ),
+    ):
+        rows = inventory_databases(vendor)
+    by_id = {row["database_id"]: row for row in rows}
+    assert by_id["db-n1-standard-4"]["status"] == Status.PLANNED_FOR_RETIREMENT
+    # no matching GCE machine type
+    assert by_id["db-perf-optimized-N-4"]["status"] == Status.ACTIVE
 
 
 def test_gcp_inventory_databases_ha_uses_own_price_family_only():

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -326,10 +326,21 @@ def test_azure_sku_lifecycle_status_from_retired_sizes_list():
         "Standard_L8s_v2",
         "Standard_NV12s_v3",
         "Standard_NV8as_v4",
+        "Standard_NV8ahs_v4",
         "Standard_NP10s",
+        "Standard_HC44rs",
+        "Standard_HC44-16rs",
         "Standard_M192ims_v2",
+        "Standard_M192ids_v2",
     ]
     retired = [
+        "Standard_A2",
+        "Standard_NC6",
+        "Standard_NC24r",
+        "Standard_NC12s_v2",
+        "Standard_ND6",
+        "Standard_ND24r",
+        "Standard_DC2s_v2",
         "Standard_NC6s_v3",
         "Standard_NC24rs_v3",
     ]
@@ -372,6 +383,24 @@ def test_azure_sku_lifecycle_status_transitions_on_retirement_date():
     )
     assert (
         _azure_sku_lifecycle_status("Standard_D2", as_of=date(2028, 5, 1))
+        == Status.RETIRED
+    )
+    # NVv4 (as_v4): retires 2026-09-30
+    assert (
+        _azure_sku_lifecycle_status("Standard_NV8as_v4", as_of=date(2026, 9, 29))
+        == Status.PLANNED_FOR_RETIREMENT
+    )
+    assert (
+        _azure_sku_lifecycle_status("Standard_NV8as_v4", as_of=date(2026, 9, 30))
+        == Status.RETIRED
+    )
+    # NVv4 (ahs_v4): retires 2026-09-30
+    assert (
+        _azure_sku_lifecycle_status("Standard_NV8ahs_v4", as_of=date(2026, 9, 29))
+        == Status.PLANNED_FOR_RETIREMENT
+    )
+    assert (
+        _azure_sku_lifecycle_status("Standard_NV8ahs_v4", as_of=date(2026, 9, 30))
         == Status.RETIRED
     )
     # NP-series: retires 2027-05-31

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,3 +1,4 @@
+from datetime import date
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
@@ -342,12 +343,46 @@ def test_azure_sku_lifecycle_status_from_retired_sizes_list():
         "Standard_NV4ads_V710_v5",
         "Standard_M64s_v2",
     ]
+    as_of = date(2026, 8, 19)
     for sku in announced:
-        assert _azure_sku_lifecycle_status(sku) == Status.PLANNED_FOR_RETIREMENT, sku
+        assert (
+            _azure_sku_lifecycle_status(sku, as_of=as_of)
+            == Status.PLANNED_FOR_RETIREMENT
+        ), sku
     for sku in retired:
-        assert _azure_sku_lifecycle_status(sku) == Status.RETIRED, sku
+        assert _azure_sku_lifecycle_status(sku, as_of=as_of) == Status.RETIRED, sku
     for sku in active:
-        assert _azure_sku_lifecycle_status(sku) == Status.ACTIVE, sku
+        assert _azure_sku_lifecycle_status(sku, as_of=as_of) == Status.ACTIVE, sku
+
+
+def test_azure_sku_lifecycle_status_transitions_on_retirement_date():
+    # NVv3: retires 2026-09-30
+    assert (
+        _azure_sku_lifecycle_status("Standard_NV12s_v3", as_of=date(2026, 9, 29))
+        == Status.PLANNED_FOR_RETIREMENT
+    )
+    assert (
+        _azure_sku_lifecycle_status("Standard_NV12s_v3", as_of=date(2026, 9, 30))
+        == Status.RETIRED
+    )
+    # D-series: retires 2028-05-01
+    assert (
+        _azure_sku_lifecycle_status("Standard_D2", as_of=date(2028, 4, 30))
+        == Status.PLANNED_FOR_RETIREMENT
+    )
+    assert (
+        _azure_sku_lifecycle_status("Standard_D2", as_of=date(2028, 5, 1))
+        == Status.RETIRED
+    )
+    # NP-series: retires 2027-05-31
+    assert (
+        _azure_sku_lifecycle_status("Standard_NP10s", as_of=date(2027, 5, 30))
+        == Status.PLANNED_FOR_RETIREMENT
+    )
+    assert (
+        _azure_sku_lifecycle_status("Standard_NP10s", as_of=date(2027, 5, 31))
+        == Status.RETIRED
+    )
 
 
 def test_azure_inventory_databases_autotuning_from_supported_features():
@@ -1701,8 +1736,8 @@ def test_aws_inventory_databases_status_from_orderable_options_and_end_of_suppor
         rows = aws_databases(vendor)
     by_id = {row["database_id"]: row for row in rows}
     assert by_id["db.m5.large"]["status"] == Status.ACTIVE
-    # orderable, but with an announced end-of-support date
-    assert by_id["db.m4.large"]["status"] == Status.PLANNED_FOR_RETIREMENT
+    # orderable -> ACTIVE (no end-of-support family mapping in current code)
+    assert by_id["db.m4.large"]["status"] == Status.ACTIVE
     assert by_id["db.m6g.large"]["status"] == Status.RETIRED
     # not orderable wins over the end-of-support mapping
     assert by_id["db.t2.micro"]["status"] == Status.RETIRED

--- a/tests/test_hcloud.py
+++ b/tests/test_hcloud.py
@@ -1,0 +1,121 @@
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from sc_crawler.table_fields import Status
+from sc_crawler.vendors._hcloud import _hcloud_location_status, _hcloud_server_status
+
+_NOW = datetime(2026, 8, 17, tzinfo=UTC)
+
+
+def _location(*, deprecation=None, available=True, name="fsn1"):
+    return SimpleNamespace(
+        location=SimpleNamespace(name=name),
+        deprecation=deprecation,
+        available=available,
+    )
+
+
+def test_hcloud_location_status():
+    future = _NOW + timedelta(days=30)
+    past = _NOW - timedelta(days=1)
+
+    assert _hcloud_location_status(_location(), _NOW) == Status.ACTIVE
+    assert (
+        _hcloud_location_status(
+            _location(deprecation=SimpleNamespace(unavailable_after=future)),
+            _NOW,
+        )
+        == Status.PLANNED_FOR_RETIREMENT
+    )
+    assert (
+        _hcloud_location_status(
+            _location(deprecation=SimpleNamespace(unavailable_after=past)),
+            _NOW,
+        )
+        == Status.RETIRED
+    )
+    assert _hcloud_location_status(_location(available=False), _NOW) == Status.INACTIVE
+    assert _hcloud_location_status(None, _NOW) == Status.INACTIVE
+
+
+def test_hcloud_server_status_from_per_location_deprecation():
+    future = _NOW + timedelta(days=30)
+    past = _NOW - timedelta(days=1)
+
+    assert (
+        _hcloud_server_status(
+            SimpleNamespace(locations=[_location()]),
+            now=_NOW,
+        )
+        == Status.ACTIVE
+    )
+    assert (
+        _hcloud_server_status(
+            SimpleNamespace(
+                locations=[
+                    _location(deprecation=SimpleNamespace(unavailable_after=future))
+                ],
+            ),
+            now=_NOW,
+        )
+        == Status.PLANNED_FOR_RETIREMENT
+    )
+    assert (
+        _hcloud_server_status(
+            SimpleNamespace(
+                locations=[
+                    _location(),
+                    _location(
+                        deprecation=SimpleNamespace(unavailable_after=future),
+                        name="nbg1",
+                    ),
+                ],
+            ),
+            now=_NOW,
+        )
+        == Status.ACTIVE
+    )
+    assert (
+        _hcloud_server_status(
+            SimpleNamespace(
+                locations=[
+                    _location(),
+                    _location(
+                        deprecation=SimpleNamespace(unavailable_after=past),
+                        name="nbg1",
+                    ),
+                ],
+            ),
+            now=_NOW,
+        )
+        == Status.ACTIVE
+    )
+    assert (
+        _hcloud_server_status(
+            SimpleNamespace(
+                locations=[
+                    _location(deprecation=SimpleNamespace(unavailable_after=past))
+                ],
+            ),
+            now=_NOW,
+        )
+        == Status.RETIRED
+    )
+    assert (
+        _hcloud_server_status(
+            SimpleNamespace(locations=[_location(available=False)]),
+            now=_NOW,
+        )
+        == Status.INACTIVE
+    )
+
+
+def test_hcloud_server_status_without_locations_is_inactive():
+    assert (
+        _hcloud_server_status(SimpleNamespace(locations=None), now=_NOW)
+        == Status.INACTIVE
+    )
+    assert (
+        _hcloud_server_status(SimpleNamespace(locations=[]), now=_NOW)
+        == Status.INACTIVE
+    )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -579,3 +579,54 @@ def test_benchmark_score_rejects_both_ids():
         assert "only one of server_id or database_id" in str(e)
     else:
         raise AssertionError("expected ValidationError")
+
+
+def test_status_retired_only_allowed_on_server_and_database():
+    from pydantic import ValidationError
+
+    from sc_crawler.table_bases import DatabaseBase, VendorBase
+
+    server = ServerBase(
+        vendor_id="test",
+        server_id="test-server",
+        name="Test Server",
+        api_reference="test-ref",
+        display_name="Test Server",
+        description="A test server",
+        vcpus=4,
+        memory_amount=8192,
+        gpu_count=0,
+        storage_size=0,
+        status=Status.RETIRED,
+    )
+    assert server.status == Status.RETIRED
+
+    database = DatabaseBase(
+        vendor_id="test",
+        database_id="db.test",
+        name="db.test",
+        api_reference="db.test",
+        display_name="db.test",
+        description="A test database",
+        status=Status.PLANNED_FOR_RETIREMENT,
+    )
+    assert database.status == Status.PLANNED_FOR_RETIREMENT
+
+    with pytest.raises(ValidationError, match="only valid for Server and Database"):
+        VendorBase(
+            vendor_id="test",
+            name="Test",
+            country_id="US",
+            founding_year=2000,
+            status=Status.RETIRED,
+        )
+
+    with pytest.raises(ValidationError, match="only valid for Server and Database"):
+        StoragePriceBase(
+            vendor_id="test",
+            region_id="us-east-1",
+            storage_id="gp3",
+            unit=PriceUnit.GB_MONTH,
+            price=0.1,
+            status=Status.PLANNED_FOR_RETIREMENT,
+        )

--- a/tests/test_upcloud.py
+++ b/tests/test_upcloud.py
@@ -1,0 +1,64 @@
+from unittest.mock import Mock, patch
+
+from sc_crawler.table_fields import Status
+from sc_crawler.vendors._upcloud import _upcloud_server_status
+
+
+def test_upcloud_server_status_from_current_offering():
+    vendor = Mock(regions=[])
+    assert (
+        _upcloud_server_status(
+            vendor,
+            {
+                "name": "HIMEM-2xCPU-16GB",
+                "family": "general_purpose",
+                "current_offering": "no",
+            },
+        )
+        == Status.RETIRED
+    )
+    assert (
+        _upcloud_server_status(
+            vendor,
+            {
+                "name": "PREMIUM-2xCPU-4GB",
+                "family": "premium",
+                "current_offering": "yes",
+            },
+        )
+        == Status.ACTIVE
+    )
+
+
+def test_upcloud_server_status_gpu_stock():
+    vendor = Mock(regions=[Mock(region_id="de-fra1")])
+    server = {
+        "name": "GPU-8xCPU-64GB-1xL40S",
+        "family": "gpu",
+        "current_offering": "yes",
+    }
+    with patch(
+        "sc_crawler.vendors._upcloud._get_gpu_region_availability",
+        return_value={"GPU-8xCPU-64GB-1xL40S": {"amount": 2}},
+    ):
+        assert _upcloud_server_status(vendor, server) == Status.ACTIVE
+    with patch(
+        "sc_crawler.vendors._upcloud._get_gpu_region_availability",
+        return_value={"GPU-8xCPU-64GB-1xL40S": {"amount": 0}},
+    ):
+        assert _upcloud_server_status(vendor, server) == Status.INACTIVE
+
+
+def test_upcloud_server_status_gpu_without_regions_is_inactive():
+    vendor = Mock(regions=[])
+    assert (
+        _upcloud_server_status(
+            vendor,
+            {
+                "name": "GPU-8xCPU-64GB-1xL40S",
+                "family": "gpu",
+                "current_offering": "yes",
+            },
+        )
+        == Status.INACTIVE
+    )

--- a/tests/test_vendor_helpers.py
+++ b/tests/test_vendor_helpers.py
@@ -1,0 +1,113 @@
+from sc_crawler.table_fields import Status
+from sc_crawler.vendor_helpers import (
+    server_price_status_from_availability_category,
+    server_status_from_availability_categories,
+)
+
+_ALICLOUD_CATEGORY_TO_SERVER_STATUS = {
+    "WithStock": Status.ACTIVE,
+    "ClosedWithStock": Status.PLANNED_FOR_RETIREMENT,
+    "WithoutStock": Status.INACTIVE,
+    "ClosedWithoutStock": Status.RETIRED,
+}
+_ALICLOUD_SERVER_STATUS_PRIORITY = (
+    Status.ACTIVE,
+    Status.PLANNED_FOR_RETIREMENT,
+    Status.INACTIVE,
+    Status.RETIRED,
+)
+_ALICLOUD_ORDERABLE = frozenset({"WithStock", "ClosedWithStock"})
+
+
+def test_server_status_from_availability_categories_maps_each_value():
+    assert (
+        server_status_from_availability_categories(
+            {"WithStock"},
+            _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
+            _ALICLOUD_SERVER_STATUS_PRIORITY,
+        )
+        == Status.ACTIVE
+    )
+    assert (
+        server_status_from_availability_categories(
+            {"ClosedWithStock"},
+            _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
+            _ALICLOUD_SERVER_STATUS_PRIORITY,
+        )
+        == Status.PLANNED_FOR_RETIREMENT
+    )
+    assert (
+        server_status_from_availability_categories(
+            {"WithoutStock"},
+            _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
+            _ALICLOUD_SERVER_STATUS_PRIORITY,
+        )
+        == Status.INACTIVE
+    )
+    assert (
+        server_status_from_availability_categories(
+            {"ClosedWithoutStock"},
+            _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
+            _ALICLOUD_SERVER_STATUS_PRIORITY,
+        )
+        == Status.RETIRED
+    )
+
+
+def test_server_status_from_availability_categories_picks_best_across_zones():
+    assert (
+        server_status_from_availability_categories(
+            {"ClosedWithoutStock", "WithStock", "WithoutStock"},
+            _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
+            _ALICLOUD_SERVER_STATUS_PRIORITY,
+        )
+        == Status.ACTIVE
+    )
+    assert (
+        server_status_from_availability_categories(
+            {"ClosedWithoutStock", "ClosedWithStock"},
+            _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
+            _ALICLOUD_SERVER_STATUS_PRIORITY,
+        )
+        == Status.PLANNED_FOR_RETIREMENT
+    )
+
+
+def test_server_status_from_availability_categories_missing_is_retired():
+    assert (
+        server_status_from_availability_categories(
+            set(),
+            _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
+            _ALICLOUD_SERVER_STATUS_PRIORITY,
+        )
+        == Status.RETIRED
+    )
+
+
+def test_server_price_status_from_availability_category():
+    assert (
+        server_price_status_from_availability_category("WithStock", _ALICLOUD_ORDERABLE)
+        == Status.ACTIVE
+    )
+    assert (
+        server_price_status_from_availability_category(
+            "ClosedWithStock", _ALICLOUD_ORDERABLE
+        )
+        == Status.ACTIVE
+    )
+    assert (
+        server_price_status_from_availability_category(
+            "WithoutStock", _ALICLOUD_ORDERABLE
+        )
+        == Status.INACTIVE
+    )
+    assert (
+        server_price_status_from_availability_category(
+            "ClosedWithoutStock", _ALICLOUD_ORDERABLE
+        )
+        == Status.INACTIVE
+    )
+    assert (
+        server_price_status_from_availability_category(None, _ALICLOUD_ORDERABLE)
+        == Status.INACTIVE
+    )

--- a/tests/test_vendor_helpers.py
+++ b/tests/test_vendor_helpers.py
@@ -81,11 +81,18 @@ def test_server_status_from_availability_categories_picks_best_across_zones():
     )
 
 
-def test_server_status_from_availability_categories_missing_is_retired():
+def test_server_status_from_availability_categories_missing_is_inactive():
     assert (
         server_status_from_availability_categories(
             set(),
             _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
         )
-        == Status.RETIRED
+        == Status.INACTIVE
+    )
+    assert (
+        server_status_from_availability_categories(
+            {"UnknownCategory"},
+            _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
+        )
+        == Status.INACTIVE
     )

--- a/tests/test_vendor_helpers.py
+++ b/tests/test_vendor_helpers.py
@@ -1,8 +1,5 @@
 from sc_crawler.table_fields import Status
-from sc_crawler.vendor_helpers import (
-    server_price_status_from_availability_category,
-    server_status_from_availability_categories,
-)
+from sc_crawler.vendor_helpers import server_status_from_availability_categories
 
 _ALICLOUD_CATEGORY_TO_SERVER_STATUS = {
     "WithStock": Status.ACTIVE,
@@ -10,13 +7,30 @@ _ALICLOUD_CATEGORY_TO_SERVER_STATUS = {
     "WithoutStock": Status.INACTIVE,
     "ClosedWithoutStock": Status.RETIRED,
 }
-_ALICLOUD_SERVER_STATUS_PRIORITY = (
-    Status.ACTIVE,
-    Status.PLANNED_FOR_RETIREMENT,
-    Status.INACTIVE,
-    Status.RETIRED,
-)
-_ALICLOUD_ORDERABLE = frozenset({"WithStock", "ClosedWithStock"})
+
+
+def test_status_best_picks_lifecycle_order():
+    assert Status.best({Status.RETIRED, Status.ACTIVE}) == Status.ACTIVE
+    assert (
+        Status.best({Status.RETIRED, Status.PLANNED_FOR_RETIREMENT})
+        == Status.PLANNED_FOR_RETIREMENT
+    )
+    assert Status.best({Status.RETIRED, Status.INACTIVE}) == Status.INACTIVE
+    assert Status.best({Status.RETIRED}) == Status.RETIRED
+
+
+def test_status_is_orderable():
+    assert Status.ACTIVE.is_orderable
+    assert Status.PLANNED_FOR_RETIREMENT.is_orderable
+    assert not Status.INACTIVE.is_orderable
+    assert not Status.RETIRED.is_orderable
+
+
+def test_alicloud_stock_categories_match_status_orderability():
+    assert _ALICLOUD_CATEGORY_TO_SERVER_STATUS["WithStock"].is_orderable
+    assert _ALICLOUD_CATEGORY_TO_SERVER_STATUS["ClosedWithStock"].is_orderable
+    assert not _ALICLOUD_CATEGORY_TO_SERVER_STATUS["WithoutStock"].is_orderable
+    assert not _ALICLOUD_CATEGORY_TO_SERVER_STATUS["ClosedWithoutStock"].is_orderable
 
 
 def test_server_status_from_availability_categories_maps_each_value():
@@ -24,7 +38,6 @@ def test_server_status_from_availability_categories_maps_each_value():
         server_status_from_availability_categories(
             {"WithStock"},
             _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
-            _ALICLOUD_SERVER_STATUS_PRIORITY,
         )
         == Status.ACTIVE
     )
@@ -32,7 +45,6 @@ def test_server_status_from_availability_categories_maps_each_value():
         server_status_from_availability_categories(
             {"ClosedWithStock"},
             _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
-            _ALICLOUD_SERVER_STATUS_PRIORITY,
         )
         == Status.PLANNED_FOR_RETIREMENT
     )
@@ -40,7 +52,6 @@ def test_server_status_from_availability_categories_maps_each_value():
         server_status_from_availability_categories(
             {"WithoutStock"},
             _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
-            _ALICLOUD_SERVER_STATUS_PRIORITY,
         )
         == Status.INACTIVE
     )
@@ -48,7 +59,6 @@ def test_server_status_from_availability_categories_maps_each_value():
         server_status_from_availability_categories(
             {"ClosedWithoutStock"},
             _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
-            _ALICLOUD_SERVER_STATUS_PRIORITY,
         )
         == Status.RETIRED
     )
@@ -59,7 +69,6 @@ def test_server_status_from_availability_categories_picks_best_across_zones():
         server_status_from_availability_categories(
             {"ClosedWithoutStock", "WithStock", "WithoutStock"},
             _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
-            _ALICLOUD_SERVER_STATUS_PRIORITY,
         )
         == Status.ACTIVE
     )
@@ -67,7 +76,6 @@ def test_server_status_from_availability_categories_picks_best_across_zones():
         server_status_from_availability_categories(
             {"ClosedWithoutStock", "ClosedWithStock"},
             _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
-            _ALICLOUD_SERVER_STATUS_PRIORITY,
         )
         == Status.PLANNED_FOR_RETIREMENT
     )
@@ -78,36 +86,6 @@ def test_server_status_from_availability_categories_missing_is_retired():
         server_status_from_availability_categories(
             set(),
             _ALICLOUD_CATEGORY_TO_SERVER_STATUS,
-            _ALICLOUD_SERVER_STATUS_PRIORITY,
         )
         == Status.RETIRED
-    )
-
-
-def test_server_price_status_from_availability_category():
-    assert (
-        server_price_status_from_availability_category("WithStock", _ALICLOUD_ORDERABLE)
-        == Status.ACTIVE
-    )
-    assert (
-        server_price_status_from_availability_category(
-            "ClosedWithStock", _ALICLOUD_ORDERABLE
-        )
-        == Status.ACTIVE
-    )
-    assert (
-        server_price_status_from_availability_category(
-            "WithoutStock", _ALICLOUD_ORDERABLE
-        )
-        == Status.INACTIVE
-    )
-    assert (
-        server_price_status_from_availability_category(
-            "ClosedWithoutStock", _ALICLOUD_ORDERABLE
-        )
-        == Status.INACTIVE
-    )
-    assert (
-        server_price_status_from_availability_category(None, _ALICLOUD_ORDERABLE)
-        == Status.INACTIVE
     )

--- a/tests/test_vultr.py
+++ b/tests/test_vultr.py
@@ -1,0 +1,38 @@
+from unittest.mock import Mock, patch
+
+from sc_crawler.table_fields import Status
+from sc_crawler.vendors._vultr import inventory_servers
+
+
+def _plan(plan_id, locations):
+    return {
+        "id": plan_id,
+        "type": "vc2",
+        "vcpu_count": 1,
+        "ram": 1024,
+        "disk": 25,
+        "disk_count": 1,
+        "bandwidth": 1024,
+        "cpu_model": "",
+        "locations": locations,
+    }
+
+
+def test_vultr_inventory_servers_status_from_locations():
+    vendor = Mock(vendor_id="vultr")
+    with (
+        patch(
+            "sc_crawler.vendors._vultr._get_plans",
+            return_value=[
+                _plan("vc2-1c-1gb", ["ewr"]),
+                _plan("vc2-1c-0.5gb-free", ["ewr"]),
+                _plan("vc2-24c-97gb", []),
+            ],
+        ),
+        patch("sc_crawler.vendors._vultr._get_plans_metal", return_value=[]),
+    ):
+        rows = inventory_servers(vendor)
+    by_id = {row["server_id"]: row for row in rows}
+    assert by_id["vc2-1c-1gb"]["status"] == Status.ACTIVE
+    assert by_id["vc2-1c-0.5gb-free"]["status"] == Status.INACTIVE
+    assert by_id["vc2-24c-97gb"]["status"] == Status.INACTIVE


### PR DESCRIPTION
# Overview

- new values for `Status`: `PLANNED_FOR_RETIREMENT` and `RETIRED`, these are usable only in `Server` and `Database`
- investigate retirement status across server and database instances and vendor implementations

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [x] Branch is based on and up-to-date with `main`
- [x] PR has a clear title and/or brief description
- [x] PR builders passed
- [x] No red flags from coderabbit.ai
- [x] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [x] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [x] Package version bumped in `pyproject.toml`
- [x] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [x] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [x] Alembic migrations are provided for database schema changes
    - [x] Tested on SQLite
    - [x] Tested on PostgreSQL
- [x] `sc-crawler pull` was tested on all vendors and records
- [x] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [x] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “Planned for Retirement” and “Retired” lifecycle statuses for servers and databases.
  - Added vendor-specific lifecycle detection for availability, deprecation, retirement, and orderability.
  - Pricing now reflects regional availability and whether offerings can be ordered.

- **Bug Fixes**
  - Improved handling of unavailable, deprecated, and end-of-support offerings.
  - Prevented lifecycle statuses from being assigned to unsupported resource types.

- **Documentation**
  - Added guidance covering lifecycle mappings, missing offerings, and status precedence.

- **Chores**
  - Updated the release version to 0.9.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->