### PR TITLE
refactor: remove deprecated cache inspection logic and update CLI to …

### DIFF
--- a/src/sc_crawler/cli.py
+++ b/src/sc_crawler/cli.py
@@ -72,7 +72,6 @@ engine_to_dialect = {
 }
 Engines = Enum("ENGINES", {k: k for k in engine_to_dialect.keys()})
 
-# Used the public logging API introduced in Python 3.11.
 log_levels = list(logging.getLevelNamesMapping().keys())
 LogLevels = StrEnum("LOGLEVELS", {k: k for k in log_levels})
 

--- a/src/sc_crawler/cli.py
+++ b/src/sc_crawler/cli.py
@@ -5,7 +5,7 @@ Check `sc-crawler --help` for more details."""
 import logging
 from contextlib import suppress
 from datetime import UTC, datetime, timedelta
-from enum import Enum
+from enum import Enum, StrEnum
 from json import dump as json_dump
 from json import loads
 from os import environ
@@ -72,9 +72,9 @@ engine_to_dialect = {
 }
 Engines = Enum("ENGINES", {k: k for k in engine_to_dialect.keys()})
 
-# TODO use logging.getLevelNamesMapping() from Python 3.11
-log_levels = list(logging._nameToLevel.keys())
-LogLevels = Enum("LOGLEVELS", {k: k for k in log_levels})
+# Used the public logging API introduced in Python 3.11.
+log_levels = list(logging.getLevelNamesMapping().keys())
+LogLevels = StrEnum("LOGLEVELS", {k: k for k in log_levels})
 
 supported_records = [r[10:] for r in dir(Vendor) if r.startswith("inventory_")]
 Records = Enum("RECORDS", {k: k for k in supported_records})
@@ -781,7 +781,7 @@ def pull(
     ] = [],
     log_level: Annotated[
         LogLevels, typer.Option(help="Log level threshold.")
-    ] = LogLevels.INFO.value,  # TODO drop .value after updating Enum to StrEnum in Python3.11
+    ] = LogLevels.INFO,
     cache: Annotated[
         bool,
         typer.Option(help="Enable or disable caching of all vendor API calls on disk."),
@@ -808,7 +808,7 @@ def pull(
     channel = ScRichHandler()
     formatter = logging.Formatter("%(message)s")
     channel.setFormatter(formatter)
-    logger.setLevel(log_level.value)
+    logger.setLevel(log_level)
     logger.addHandler(channel)
 
     # filter vendors

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -1170,27 +1170,6 @@ def _standardize_gpu_family(server):
     return family
 
 
-# TODO: deprecated, deletable once we successfully avoid corrupted lscpu cache data
-def _l123_cache(lscpu: dict, level: int):
-    if level == 1:
-        # don't include instruction cache
-        cache = int(_listsearch(lscpu, "field", "L1d cache:")["data"].split(" ")[0])
-        if cache > 32 * 1024 * 1024:  # 32 MiB+ is potentially corrupted data
-            return None
-        return cache
-    elif level == 2:
-        cache = int(_listsearch(lscpu, "field", "L2 cache:")["data"].split(" ")[0])
-        if cache > 512 * 1024 * 1024:  # 512 MiB+ is potentially corrupted data
-            return None
-        return cache
-    elif level == 3:
-        cache = int(_listsearch(lscpu, "field", "L3 cache:")["data"].split(" ")[0])
-        if cache > 1024 * 1024 * 1024:  # 1 GiB+ is potentially corrupted data
-            return None
-        return cache
-    else:
-        raise ValueError("Not known cache level.")
-
 
 def _dropna(text: str) -> str:
     if text in ["N/A"]:

--- a/src/sc_crawler/inspector.py
+++ b/src/sc_crawler/inspector.py
@@ -1170,7 +1170,6 @@ def _standardize_gpu_family(server):
     return family
 
 
-
 def _dropna(text: str) -> str:
     if text in ["N/A"]:
         return None


### PR DESCRIPTION
## Overview

Clean up deprecated APIs and remove unused cache inspection logic.

Changes:

- Replace the private `logging._nameToLevel` API with the public `logging.getLevelNamesMapping()` API.
- Use `StrEnum` for `LogLevels` so `.value` is no longer needed.
- Remove the unused `_l123_cache` function and its deprecation TODO.

Tests:

- `pytest` passes.
- `git diff --check` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging-level handling for more reliable command-line output.
  * Updated logging options to use supported Python APIs.

* **Refactor**
  * Removed obsolete cache-processing logic from inspection workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->