### PR TITLE
Dev 950 fix aws server status bug

### DIFF
--- a/src/sc_crawler/vendors/_aws.py
+++ b/src/sc_crawler/vendors/_aws.py
@@ -1145,9 +1145,7 @@ def inventory_server_prices_spot(vendor):
         )
         vendor.progress_tracker.advance_task()
     vendor.progress_tracker.hide_task()
-    _reconcile_server_status(
-        vendor, {product["InstanceType"] for product in products}
-    )
+    _reconcile_server_status(vendor, {product["InstanceType"] for product in products})
     return server_prices
 
 

--- a/src/sc_crawler/vendors/_aws.py
+++ b/src/sc_crawler/vendors/_aws.py
@@ -7,7 +7,7 @@ from functools import cache
 from itertools import chain, repeat
 from logging import DEBUG, WARN
 from statistics import mode
-from typing import List, Optional, Tuple
+from typing import Collection, List, Optional, Tuple
 
 import boto3
 from botocore.config import Config
@@ -120,6 +120,51 @@ def _describe_instance_type_offerings_per_zone_with_progress(
     zones = _describe_instance_type_offerings_per_zone(region)
     vendor.progress_tracker.advance_task()
     return zones
+
+
+def _collect_regions_servers(vendor: Vendor) -> dict[str, dict[str, list[str]]]:
+    """Map each ACTIVE region to instance types offered per zone."""
+    active_region_ids = [
+        region.api_reference
+        for region in vendor.regions
+        if region.status == Status.ACTIVE
+    ]
+    vendor.progress_tracker.start_task(
+        name="Look up supported server types in all ACTIVE regions/zones",
+        total=len(active_region_ids),
+    )
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        regions_servers = executor.map(
+            _describe_instance_type_offerings_per_zone_with_progress,
+            active_region_ids,
+            repeat(vendor),
+        )
+    regions_servers = dict(zip(active_region_ids, regions_servers))
+    vendor.progress_tracker.hide_task()
+    return regions_servers
+
+
+def _reconcile_server_status(
+    vendor: Vendor, spot_server_ids: Collection[str] = ()
+) -> None:
+    """Update server status from EC2 offerings and spot availability.
+
+    Not offered in any ACTIVE region/zone and absent from spot -> INACTIVE.
+    AWS does not confirm retirement, so never mark RETIRED here.
+    """
+    regions_servers = _collect_regions_servers(vendor)
+    offered_server_ids = {
+        server_id
+        for zone_servers in regions_servers.values()
+        for server_id in zone_servers
+    }
+    available_server_ids = offered_server_ids | set(spot_server_ids)
+    for server in vendor.servers:
+        server.status = (
+            Status.ACTIVE
+            if server.server_id in available_server_ids
+            else Status.INACTIVE
+        )
 
 
 @cachier()
@@ -951,8 +996,9 @@ def inventory_zones(vendor):
 def inventory_servers(vendor):
     """List all available AWS instance types in all regions via `boto3` calls.
 
-    Lifecycle (`DescribeInstanceTypeOfferings`): not offered in any active
-    region/zone -> INACTIVE. No type-level EC2 retirement API exists.
+    Lifecycle is reconciled after spot price collection via
+    [_reconcile_server_status][sc_crawler.vendors._aws._reconcile_server_status]
+    (offerings + spot in ACTIVE regions -> ACTIVE, else INACTIVE).
     """
     # TODO consider dropping this in favor of pricing.get_products, as
     #      it has info e.g. on instanceFamily although other fields
@@ -990,22 +1036,7 @@ def inventory_server_prices(vendor):
     regions = scmodels_to_dict(vendor.regions, keys=["name", "aliases"])
     servers = scmodels_to_dict(vendor.servers, keys=["server_id"])
 
-    # check all regions for instance types per zone
-    active_region_ids = [
-        r.api_reference for r in regions.values() if r.status == Status.ACTIVE
-    ]
-    vendor.progress_tracker.start_task(
-        name="Look up supported server types in all ACTIVE regions/zones",
-        total=len(active_region_ids),
-    )
-    with ThreadPoolExecutor(max_workers=8) as executor:
-        regions_servers = executor.map(
-            _describe_instance_type_offerings_per_zone_with_progress,
-            active_region_ids,
-            repeat(vendor),
-        )
-    regions_servers = dict(zip(active_region_ids, regions_servers))
-    vendor.progress_tracker.hide_task()
+    regions_servers = _collect_regions_servers(vendor)
 
     server_prices = []
     vendor.progress_tracker.start_task(
@@ -1046,17 +1077,6 @@ def inventory_server_prices(vendor):
         finally:
             vendor.progress_tracker.advance_task()
     vendor.progress_tracker.hide_task()
-
-    # Not offered in any ACTIVE region/zone. AWS does not confirm retirement,
-    # so mark INACTIVE rather than RETIRED. Prices may still be published.
-    offered_server_ids = {
-        server_id
-        for zone_servers in regions_servers.values()
-        for server_id in zone_servers
-    }
-    for server in vendor.servers:
-        if server.server_id not in offered_server_ids:
-            server.status = Status.INACTIVE
 
     return server_prices
 
@@ -1125,6 +1145,9 @@ def inventory_server_prices_spot(vendor):
         )
         vendor.progress_tracker.advance_task()
     vendor.progress_tracker.hide_task()
+    _reconcile_server_status(
+        vendor, {product["InstanceType"] for product in products}
+    )
     return server_prices
 
 

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -33,6 +33,9 @@ from sc_crawler.vendors._aws import (
     inventory_databases as aws_databases,
 )
 from sc_crawler.vendors._aws import (
+    _reconcile_server_status as aws_reconcile_server_status,
+)
+from sc_crawler.vendors._aws import (
     inventory_server_prices as aws_server_prices,
 )
 from sc_crawler.vendors._azure import (
@@ -1820,6 +1823,7 @@ def test_aws_inventory_server_prices_deactivates_unoffered_instance_types():
         ),
     ):
         prices = aws_server_prices(vendor)
+        aws_reconcile_server_status(vendor)
     assert {(p["server_id"], p["zone_id"]) for p in prices} == {
         ("m5.large", "use1-az1")
     }
@@ -1828,6 +1832,24 @@ def test_aws_inventory_server_prices_deactivates_unoffered_instance_types():
     assert t1.status == Status.INACTIVE
     # offered, even without a Linux on-demand SKU
     assert mac.status == Status.ACTIVE
+
+
+def test_aws_reconcile_server_status_keeps_spot_only_instance_types_active():
+    region = Mock(
+        region_id="us-east-1",
+        api_reference="us-east-1",
+        aliases=[],
+        status=Status.ACTIVE,
+    )
+    region.name = "US East (N. Virginia)"
+    spot_only = Mock(server_id="p4d.24xlarge", status=Status.INACTIVE)
+    vendor = _aws_vendor(regions=[region], servers=[spot_only])
+    with patch(
+        "sc_crawler.vendors._aws._describe_instance_type_offerings_per_zone_with_progress",
+        return_value={},
+    ):
+        aws_reconcile_server_status(vendor, spot_server_ids={"p4d.24xlarge"})
+    assert spot_only.status == Status.ACTIVE
 
 
 def test_aws_inventory_database_prices_by_ha_deployment():

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -21,6 +21,9 @@ from sc_crawler.vendors._aws import (
     _get_storage_bounds_from_orderable_options,
 )
 from sc_crawler.vendors._aws import (
+    _reconcile_server_status as aws_reconcile_server_status,
+)
+from sc_crawler.vendors._aws import (
     inventory_database_prices as aws_database_prices,
 )
 from sc_crawler.vendors._aws import (
@@ -31,9 +34,6 @@ from sc_crawler.vendors._aws import (
 )
 from sc_crawler.vendors._aws import (
     inventory_databases as aws_databases,
-)
-from sc_crawler.vendors._aws import (
-    _reconcile_server_status as aws_reconcile_server_status,
 )
 from sc_crawler.vendors._aws import (
     inventory_server_prices as aws_server_prices,


### PR DESCRIPTION
# Overview

Set `Server.status` after `inventory_server_prices_spot` instead of set `INACTIVE` from ondemand pricing alone

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS server status reconciliation across on-demand and spot availability.
  * Servers are now marked active when available in an active region or zone, or when found in spot price history.
  * Prevented spot-only instance types from being incorrectly marked inactive.

* **Tests**
  * Added coverage validating that spot-only AWS instance types remain active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->