### PR TITLE
Raise API timeout to 30 secs in Vultr vendor module

### DIFF
--- a/src/sc_crawler/vendors/_vultr.py
+++ b/src/sc_crawler/vendors/_vultr.py
@@ -22,6 +22,8 @@ from ..table_fields import (
 )
 from ..utils import _HOURS_PER_MONTH, _MIB_PER_GIB
 
+_API_TIMEOUT = 30
+
 _REGION_LOCATIONS: dict[str, dict] = {
     "ams": {"lat": 52.3676, "lon": 4.9041},
     "atl": {"lat": 33.7490, "lon": -84.3880, "state": "Georgia"},
@@ -379,7 +381,9 @@ def _database_description(
 @cachier(separate_files=True)
 def _get_regions():
     response = get(
-        "https://api.vultr.com/v2/regions", params={"per_page": 500}, timeout=10
+        "https://api.vultr.com/v2/regions",
+        params={"per_page": 500},
+        timeout=_API_TIMEOUT,
     )
     return response.json()["regions"]
 
@@ -387,7 +391,7 @@ def _get_regions():
 @cachier(separate_files=True)
 def _get_plans():
     response = get(
-        "https://api.vultr.com/v2/plans", params={"per_page": 500}, timeout=10
+        "https://api.vultr.com/v2/plans", params={"per_page": 500}, timeout=_API_TIMEOUT
     )
     return response.json()["plans"]
 
@@ -395,7 +399,9 @@ def _get_plans():
 @cachier(separate_files=True)
 def _get_plans_metal():
     response = get(
-        "https://api.vultr.com/v2/plans-metal", params={"per_page": 500}, timeout=10
+        "https://api.vultr.com/v2/plans-metal",
+        params={"per_page": 500},
+        timeout=_API_TIMEOUT,
     )
     return response.json()["plans_metal"]
 
@@ -414,7 +420,7 @@ def _get_database_plans():
         "https://api.vultr.com/v2/databases/plans",
         headers=_vultr_auth_headers(),
         params={"engine": "pg", "per_page": 500},
-        timeout=10,
+        timeout=_API_TIMEOUT,
     )
     response.raise_for_status()
     return response.json().get("plans", [])
@@ -426,7 +432,7 @@ def _get_database_available_services():
         "https://api.vultr.com/v2/databases/available-services",
         headers=_vultr_auth_headers(),
         params={"per_page": 500},
-        timeout=10,
+        timeout=_API_TIMEOUT,
     )
     response.raise_for_status()
     return response.json()


### PR DESCRIPTION
# Overview

Raise API timeout to 30 secs in `Vultr` vendor module.

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the timeout for Vultr API requests to 30 seconds, improving reliability when retrieving regions, plans, databases, and available services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->