### PR TITLE
Wrap vendor pull loop in Sentry and clean up error output

### DIFF
--- a/src/sc_crawler/cli.py
+++ b/src/sc_crawler/cli.py
@@ -41,7 +41,7 @@ from .alembic_helpers import alembic_cfg, get_revision
 from .insert import insert_items
 from .logger import ProgressPanel, ScRichHandler, VendorProgressTracker, logger
 from .lookup import benchmarks, compliance_frameworks, countries
-from .sentry import before_send
+from .sentry import before_send, sentry_capture_or_raise
 from .table_fields import Status
 from .tables import Benchmark, ComplianceFramework, Country, Metadata, Vendor, tables
 from .tables_scd import tables_scd
@@ -866,47 +866,61 @@ def pull(
             # get data for each vendor and then add/merge to database
             # TODO each vendor should open its own session and run in parallel
             for vendor in vendors:
-                logger.info("Starting to collect data from vendor: " + vendor.vendor_id)
-                vendor = session.merge(vendor)
-                # register session to the Vendor so that dependen objects can auto-merge
-                vendor.session = session
-                # register progress bars so that helpers can update
-                vendor.progress_tracker = VendorProgressTracker(
-                    vendor=vendor, progress_panel=pbars
-                )
-                vendor.progress_tracker.start_vendor(total=len(records))
-                if Records.compliance_frameworks in records:
-                    vendor.inventory_compliance_frameworks()
-                if Records.regions in records:
-                    vendor.inventory_regions()
-                if Records.zones in records:
-                    vendor.inventory_zones()
-                if Records.servers in records:
-                    vendor.inventory_servers()
-                if Records.server_prices in records:
-                    vendor.inventory_server_prices()
-                if Records.server_prices_spot in records:
-                    vendor.inventory_server_prices_spot()
-                if Records.storages in records:
-                    vendor.inventory_storages()
-                if Records.storage_prices in records:
-                    vendor.inventory_storage_prices()
-                if Records.traffic_prices in records:
-                    vendor.inventory_traffic_prices()
-                if Records.ipv4_prices in records:
-                    vendor.inventory_ipv4_prices()
-                if Records.databases in records:
-                    vendor.inventory_databases()
-                if Records.database_prices in records:
-                    vendor.inventory_database_prices()
-                if Records.database_storages in records:
-                    vendor.inventory_database_storages()
-                if Records.database_storage_prices in records:
-                    vendor.inventory_database_storage_prices()
-                # reset current step name
-                vendor.progress_tracker.update_vendor(step="✔")
-                session.merge(vendor)
-                session.commit()
+
+                def on_error():
+                    vendor.log(
+                        f"Skipping vendor {vendor.vendor_id} due to vendor API error.",
+                        logging.ERROR,
+                    )
+                    vendor.progress_tracker.update_vendor(step="✘")
+
+                with sentry_capture_or_raise(
+                    vendor=vendor,
+                    on_error=on_error,
+                ):
+                    logger.info(
+                        "Starting to collect data from vendor: " + vendor.vendor_id
+                    )
+                    vendor = session.merge(vendor)
+                    # register session to the Vendor so that dependen objects can auto-merge
+                    vendor.session = session
+                    # register progress bars so that helpers can update
+                    vendor.progress_tracker = VendorProgressTracker(
+                        vendor=vendor, progress_panel=pbars
+                    )
+                    vendor.progress_tracker.start_vendor(total=len(records))
+                    if Records.compliance_frameworks in records:
+                        vendor.inventory_compliance_frameworks()
+                    if Records.regions in records:
+                        vendor.inventory_regions()
+                    if Records.zones in records:
+                        vendor.inventory_zones()
+                    if Records.servers in records:
+                        vendor.inventory_servers()
+                    if Records.server_prices in records:
+                        vendor.inventory_server_prices()
+                    if Records.server_prices_spot in records:
+                        vendor.inventory_server_prices_spot()
+                    if Records.storages in records:
+                        vendor.inventory_storages()
+                    if Records.storage_prices in records:
+                        vendor.inventory_storage_prices()
+                    if Records.traffic_prices in records:
+                        vendor.inventory_traffic_prices()
+                    if Records.ipv4_prices in records:
+                        vendor.inventory_ipv4_prices()
+                    if Records.databases in records:
+                        vendor.inventory_databases()
+                    if Records.database_prices in records:
+                        vendor.inventory_database_prices()
+                    if Records.database_storages in records:
+                        vendor.inventory_database_storages()
+                    if Records.database_storage_prices in records:
+                        vendor.inventory_database_storage_prices()
+                    # reset current step name
+                    vendor.progress_tracker.update_vendor(step="✔")
+                    session.merge(vendor)
+                    session.commit()
 
             if Records.servers in records:
                 task_id = pbars.tasks.add_task(

--- a/src/sc_crawler/cli.py
+++ b/src/sc_crawler/cli.py
@@ -868,6 +868,7 @@ def pull(
             for vendor in vendors:
 
                 def on_error():
+                    session.rollback()
                     vendor.log(
                         f"Skipping vendor {vendor.vendor_id} due to vendor API error.",
                         logging.ERROR,

--- a/src/sc_crawler/vendors/_alicloud.py
+++ b/src/sc_crawler/vendors/_alicloud.py
@@ -3,7 +3,7 @@ from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
 from functools import cache
 from itertools import chain
-from logging import INFO, WARN
+from logging import CRITICAL, INFO, WARN, getLogger
 from os import environ
 from random import shuffle
 from time import time
@@ -91,6 +91,9 @@ def _alibabacloud_config(region_id: str) -> Config:
         if security_token:
             config.security_token = security_token
         return config
+    # The SDK attaches its own stderr handler to the `credentials` logger and
+    # logs a full traceback, the resolved failure is reported once by the caller.
+    getLogger("credentials").setLevel(CRITICAL)
     return Config(credential=CredClient(), region_id=region_id, **timeout_kwargs)
 
 

--- a/src/sc_crawler/vendors/_alicloud.py
+++ b/src/sc_crawler/vendors/_alicloud.py
@@ -91,8 +91,7 @@ def _alibabacloud_config(region_id: str) -> Config:
         if security_token:
             config.security_token = security_token
         return config
-    # The SDK attaches its own stderr handler to the `credentials` logger and
-    # logs a full traceback, the resolved failure is reported once by the caller.
+    # SDK logs a full traceback per credential provider, caller reports the failure once.
     getLogger("credentials").setLevel(CRITICAL)
     return Config(credential=CredClient(), region_id=region_id, **timeout_kwargs)
 


### PR DESCRIPTION
# Overview

Wrap vendor pull loop in `sentry_capture_or_raise` and clean up error output.

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vendor inventory collection errors during `pull` are now handled individually, allowing processing to continue for other vendors.
  * Failed vendor changes are rolled back to prevent incomplete data from being retained.
  * Failed vendors are clearly marked as skipped in progress output and logged as errors.
  * Reduced unnecessary credential-related logging when using Alibaba Cloud’s default credential chain, making command output easier to review.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->