### PR TITLE
Fix DBaaS storage and GCP Cloud SQL catalog mismatches

### DIFF
--- a/src/sc_crawler/cli.py
+++ b/src/sc_crawler/cli.py
@@ -796,12 +796,11 @@ def pull(
     Vendor API calls are optionally cached as Pickle objects in `~/.cachier`.
     """
 
-    # enable caching
-    if cache:
-        set_global_params(
-            caching_enabled=True,
-            stale_after=timedelta(minutes=cache_ttl),
-        )
+    # cachier caches by default, so need to disable explicitly
+    set_global_params(
+        caching_enabled=cache,
+        stale_after=timedelta(minutes=cache_ttl),
+    )
 
     # enable logging
     channel = ScRichHandler()

--- a/src/sc_crawler/vendors/_aws.py
+++ b/src/sc_crawler/vendors/_aws.py
@@ -2,7 +2,7 @@ import json
 import re
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime, timedelta
+from datetime import datetime
 from functools import cache
 from itertools import chain, repeat
 from logging import DEBUG, WARN
@@ -12,7 +12,7 @@ from typing import Collection, List, Optional, Tuple
 import boto3
 from botocore.config import Config
 from botocore.exceptions import ClientError
-from cachier import cachier, set_global_params
+from cachier import cachier
 
 from ..inspector import _standardize_gpu_count
 from ..logger import logger
@@ -51,9 +51,6 @@ from ..vendor_helpers import (
     parallel_fetch_servers,
     preprocess_servers,
 )
-
-# disable caching by default
-set_global_params(caching_enabled=False, stale_after=timedelta(days=1))
 
 # ##############################################################################
 # Cached boto3 wrappers

--- a/src/sc_crawler/vendors/_azure.py
+++ b/src/sc_crawler/vendors/_azure.py
@@ -1850,6 +1850,18 @@ def inventory_databases(vendor):
                     for storage_edition in (
                         getattr(edition, "supported_storage_editions", None) or []
                     ):
+                        if (
+                            getattr(storage_edition, "reason", None)
+                            == _PG_UNSUPPORTED_STORAGE_REASON
+                        ):
+                            continue
+                        # Premium SSD v2 is GP/MO only; Burstable is capped by Premium SSD (~32 TiB).
+                        # https://learn.microsoft.com/en-us/azure/postgresql/compute-storage/concepts-storage-premium-ssd-v2
+                        if (
+                            edition.name == "Burstable"
+                            and storage_edition.name == "ManagedDiskV2"
+                        ):
+                            continue
                         for storage_mb in (
                             getattr(storage_edition, "supported_storage_mb", None) or []
                         ):

--- a/src/sc_crawler/vendors/_azure.py
+++ b/src/sc_crawler/vendors/_azure.py
@@ -1855,7 +1855,7 @@ def inventory_databases(vendor):
                             == _PG_UNSUPPORTED_STORAGE_REASON
                         ):
                             continue
-                        # Premium SSD v2 is GP/MO only; Burstable is capped by Premium SSD (~32 TiB).
+                        # Premium SSD v2 is General Purpose and Memory Optimized only, Burstable is capped by Premium SSD (~32 TiB).
                         # https://learn.microsoft.com/en-us/azure/postgresql/compute-storage/concepts-storage-premium-ssd-v2
                         if (
                             edition.name == "Burstable"

--- a/src/sc_crawler/vendors/_azure.py
+++ b/src/sc_crawler/vendors/_azure.py
@@ -1668,13 +1668,19 @@ _PG_SKU_NAME_PREFIX = {
     "GeneralPurpose": "GP",
     "MemoryOptimized": "MO",
 }
-_PG_FLEX_STORAGE_PRODUCT = "Az DB for PostgreSQL Flexible Server Storage"
-_PG_FLEX_BACKUP_PRODUCT = "Azure Database for PostgreSQL Flexible Server Backup Storage"
 _PG_STORAGE_RETAIL_TO_ID = {
     "storage data stored": "ManagedDisk",
     "premium ssd v2 storage data stored": "ManagedDiskV2",
     "ultra disk storage data stored": "UltraDisk",
+    "backup storage lrs data stored": "BackupStorageLRS",
 }
+_PG_STORAGE_RETAIL_PRODUCTS = frozenset(
+    {
+        "azure database for postgresql flex server storage",
+        "az db for postgresql flexible server storage",
+        "azure database for postgresql flexible server backup storage",
+    }
+)
 _PG_STORAGE_DESCRIPTIONS = {
     "ManagedDisk": "Premium SSD managed disk",
     "ManagedDiskV2": "Premium SSD v2 managed disk",
@@ -2299,17 +2305,13 @@ def inventory_database_storage_prices(vendor):
         with sentry_capture_or_raise(vendor=vendor):
             supported_storage_ids = _pg_supported_storage_ids(location)
             for item in _pg_retail_prices(location):
-                product = item.get("productName") or ""
+                product = (item.get("productName") or "").lower()
                 meter = (item.get("meterName") or "").lower()
-                if product == _PG_FLEX_STORAGE_PRODUCT:
-                    storage_id = _PG_STORAGE_RETAIL_TO_ID.get(meter)
-                elif (
-                    product == _PG_FLEX_BACKUP_PRODUCT
-                    and meter == "backup storage lrs data stored"
-                ):
-                    storage_id = _PG_BACKUP_STORAGE_ID
-                else:
-                    storage_id = None
+                storage_id = (
+                    _PG_STORAGE_RETAIL_TO_ID.get(meter)
+                    if product in _PG_STORAGE_RETAIL_PRODUCTS
+                    else None
+                )
                 if not storage_id:
                     continue
                 if (

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -1109,8 +1109,12 @@ def _pg_sqladmin_metadata() -> dict:
         if name in _PG_EXTENSION_FLAGS:
             custom_extensions = True
         for version in flag.get("appliesTo", []):
-            if isinstance(version, str) and version.startswith("POSTGRES_"):
-                engine_versions.add(version.removeprefix("POSTGRES_").replace("_", "."))
+            if not (isinstance(version, str) and version.startswith("POSTGRES_")):
+                continue
+            # flags.list appliesTo can include unreleased majors (e.g. POSTGRES_19).
+            major = version.removeprefix("POSTGRES_").replace("_", ".")
+            if major in _PG_SUPPORTED_MAJOR_VERSIONS:
+                engine_versions.add(major)
     return {
         "tiers": tiers,
         "engine_versions": sorted(
@@ -1129,7 +1133,19 @@ def _cloud_sql_skus():
 
 _PG_CUSTOM_TIER_RE = recompile(r"^db-custom-(\d+)-(\d+)$")
 _PG_NAMED_TIER_CPU_RE = recompile(r"-(\d+)$")
-_PG_N4_TIER_MARKERS = ("c4a", "perf-optimized", "memory-optimized")
+# Enterprise Plus predefined tiers (N2 / C4A), not Enterprise N4 customs.
+# Billing uses distinct Enterprise Plus SKUs.
+# https://cloud.google.com/skus/sku-groups/cloud-sql-cud-eligible-skus
+_PG_ENTERPRISE_PLUS_N_MARKERS = ("perf-optimized", "memory-optimized")
+_PG_ENTERPRISE_PLUS_C4A_MARKERS = ("c4a",)
+_PG_ENTERPRISE_PLUS_FAMILIES = frozenset({"enterprise_plus_n", "enterprise_plus_c4a"})
+# https://cloud.google.com/sql/docs/postgres/faq
+_PG_SUPPORTED_MAJOR_VERSIONS = frozenset(
+    {"9.6", "10", "11", "12", "13", "14", "15", "16", "17", "18"}
+)
+_PG_ENTERPRISE_PLUS_MAJOR_VERSIONS = frozenset(
+    {"12", "13", "14", "15", "16", "17", "18"}
+)
 _PG_SHARED_TIERS = {"db-f1-micro": "f1-micro", "db-g1-small": "g1-small"}
 _PG_STORAGE_METERS = (
     (
@@ -1191,13 +1207,7 @@ _PG_STORAGE_SPECS: dict[str, dict] = {
     },
 }
 _PG_SHARED_INSTANCE_RE = recompile(
-    r": (?:Zonal|Regional) - (?:Extended support )?(f1-micro|g1-small)(?: v\d+)? in "
-)
-_PG_VCPU_RE = recompile(
-    r": (?:Zonal|Regional) - (?:Extended support )?(?:Enterprise N4 )?vCPU in "
-)
-_PG_RAM_RE = recompile(
-    r": (?:Zonal|Regional) - (?:Extended support )?(?:Enterprise N4 )?RAM in "
+    r"(?:Extended support )?(f1-micro|g1-small)(?: v\d+)? in "
 )
 _PG_EXTENSION_FLAGS = frozenset(
     {
@@ -1217,6 +1227,52 @@ _PG_TIER_FAMILY_LABELS = {
     "memory-optimized-N": "Memory Optimized N",
     "custom": "Custom",
 }
+
+
+def _pg_tier_price_family(tier_name: str) -> str:
+    if tier_name in _PG_SHARED_TIERS:
+        return "shared"
+    lower = tier_name.lower()
+    if any(marker in lower for marker in _PG_ENTERPRISE_PLUS_C4A_MARKERS):
+        return "enterprise_plus_c4a"
+    if any(marker in lower for marker in _PG_ENTERPRISE_PLUS_N_MARKERS):
+        return "enterprise_plus_n"
+    return "enterprise"
+
+
+def _pg_compute_sku_class(description: str) -> tuple[str, str] | None:
+    """Map a Cloud SQL Postgres compute SKU description to (price_family, component)."""
+    if "for Postgre" not in description:
+        return None
+    if "vCPU in" in description:
+        component = "vcpu"
+    elif "RAM in" in description:
+        component = "ram"
+    else:
+        return None
+
+    if match := _PG_SHARED_INSTANCE_RE.search(description):
+        return ("shared", match.group(1))
+
+    extended = "Extended support" in description
+    # Match Plus / N4 before plain enterprise.
+    if (
+        "Enterprise Plus Performance Optimized C4A" in description
+        or "Enterprise Plus C4A" in description
+    ):
+        family = "enterprise_plus_c4a"
+    elif "Enterprise Plus N " in description:
+        family = "enterprise_plus_n"
+    elif "Enterprise N4" in description:
+        family = "enterprise_n4"
+    elif extended:
+        family = "enterprise_extended"
+    else:
+        family = "enterprise"
+
+    if extended and family not in ("enterprise_extended", "shared"):
+        return None
+    return (family, component)
 
 
 def _sku_unit_price(sku) -> float | None:
@@ -1253,8 +1309,6 @@ def _pg_billing_catalog() -> tuple[
     ha_families: set[tuple[str, str]] = set()
     for sku in _cloud_sql_skus():
         description = sku.description or ""
-        if "for Postgre" not in description:
-            continue
         if "Regional" in description:
             availability = "regional"
         elif "Zonal" in description:
@@ -1262,28 +1316,7 @@ def _pg_billing_catalog() -> tuple[
         else:
             continue
 
-        sku_class = None
-        if match := _PG_SHARED_INSTANCE_RE.search(description):
-            sku_class = ("shared", match.group(1))
-        else:
-            extended = "Extended support" in description
-            if _PG_VCPU_RE.search(description):
-                family = (
-                    "enterprise_n4" if "Enterprise N4" in description else "enterprise"
-                )
-                if extended and family == "enterprise":
-                    sku_class = ("enterprise_extended", "vcpu")
-                elif not extended:
-                    sku_class = (family, "vcpu")
-            elif _PG_RAM_RE.search(description):
-                family = (
-                    "enterprise_n4" if "Enterprise N4" in description else "enterprise"
-                )
-                if extended and family == "enterprise":
-                    sku_class = ("enterprise_extended", "ram")
-                elif not extended:
-                    sku_class = (family, "ram")
-
+        sku_class = _pg_compute_sku_class(description)
         if not sku_class:
             continue
         family, component = sku_class
@@ -1369,12 +1402,20 @@ def inventory_databases(vendor):
         else:
             tier_regions = []
 
-        if tier_name in _PG_SHARED_TIERS:
-            price_family = "shared"
-        elif any(marker in tier_name.lower() for marker in _PG_N4_TIER_MARKERS):
-            price_family = "enterprise_n4"
-        else:
-            price_family = "enterprise"
+        price_family = _pg_tier_price_family(tier_name)
+        is_enterprise_plus = price_family in _PG_ENTERPRISE_PLUS_FAMILIES
+        # Drop unreleased majors that flags.list may still advertise (e.g. 19).
+        engine_versions = [
+            version
+            for version in meta["engine_versions"]
+            if version in _PG_SUPPORTED_MAJOR_VERSIONS
+        ]
+        if is_enterprise_plus:
+            engine_versions = [
+                version
+                for version in engine_versions
+                if version in _PG_ENTERPRISE_PLUS_MAJOR_VERSIONS
+            ]
 
         ha: list[DatabaseHaLevel] = []
         ha_strategy: list[DatabaseHaStrategy] = []
@@ -1414,7 +1455,7 @@ def inventory_databases(vendor):
                 "server_id": server_id,
                 "engine": DatabaseEngine.POSTGRESQL,
                 "wire_protocol": DatabaseWireProtocol.POSTGRESQL,
-                "engine_versions": meta["engine_versions"],
+                "engine_versions": engine_versions,
                 "family": family_slug,
                 "vcpus": cpu_count,
                 "memory_amount": memory_amount,
@@ -1456,7 +1497,7 @@ def inventory_databases(vendor):
                 # https://cloud.google.com/sql/docs/postgres/backup-recovery/configure-pitr
                 # Max transactionLogRetentionDays for PITR by edition; not in tiers API.
                 # Enterprise: 1-7 days; Enterprise Plus: 1-35 days.
-                "continuous_backups": (35 if price_family == "enterprise_n4" else 7),
+                "continuous_backups": (35 if is_enterprise_plus else 7),
                 "custom_config": meta["custom_config"],
                 "custom_extensions": meta["custom_extensions"],
                 # https://cloud.google.com/sql/docs/postgres/replication
@@ -1471,14 +1512,14 @@ def inventory_databases(vendor):
                 "database_monitoring": True,
                 # https://cloud.google.com/sql/docs/postgres/use-index-advisor
                 # Index advisor recommends CREATE INDEX (Enterprise Plus only); operator applies.
-                "autotuning_advice": price_family == "enterprise_n4",
+                "autotuning_advice": is_enterprise_plus,
                 "autotuning_apply": False,
                 # https://cloud.google.com/sql/sla
                 # Enterprise Plus + HA: 99.99%; Enterprise + HA: 99.95%.
                 # Shared-core and zonal (non-HA) instances are excluded from the SLA.
                 "sla": (
                     99.99
-                    if price_family == "enterprise_n4" and has_regional_ha
+                    if is_enterprise_plus and has_regional_ha
                     else (
                         99.95
                         if DatabaseHaLevel.MULTI_ZONE in ha and price_family != "shared"
@@ -1528,15 +1569,8 @@ def inventory_database_prices(vendor):
         else:
             tier_regions = set()
 
-        if tier_name in _PG_SHARED_TIERS:
-            price_family = "shared"
-            availabilities = ("zonal", "regional")
-        elif any(marker in tier_name.lower() for marker in _PG_N4_TIER_MARKERS):
-            price_family = "enterprise_n4"
-            availabilities = ("zonal", "regional")
-        else:
-            price_family = "enterprise"
-            availabilities = ("zonal", "regional")
+        price_family = _pg_tier_price_family(tier_name)
+        availabilities = ("zonal", "regional")
 
         for region in vendor.regions:
             if tier_regions and region.api_reference not in tier_regions:
@@ -1560,11 +1594,11 @@ def inventory_database_prices(vendor):
                     vcpu_sku = compute_index.get(
                         (region.api_reference, price_family, "vcpu", availability)
                     )
-                    # N4/C4A billing has Enterprise N4 vCPU meters, but RAM uses the
-                    # generic PostgreSQL RAM meters (no "Enterprise N4 RAM" SKU).
                     ram_sku = compute_index.get(
                         (region.api_reference, price_family, "ram", availability)
                     )
+                    # Enterprise N4 customs (if cataloged later) may lack a dedicated
+                    # RAM meter; Plus N / C4A have their own RAM SKUs.
                     if ram_sku is None and price_family == "enterprise_n4":
                         ram_sku = compute_index.get(
                             (region.api_reference, "enterprise", "ram", availability)

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -1131,13 +1131,13 @@ def _cloud_sql_skus():
     return _skus("Cloud SQL")
 
 
-_PG_CUSTOM_TIER_RE = recompile(r"^db-custom-(\d+)-(\d+)$")
 _PG_NAMED_TIER_CPU_RE = recompile(r"-(\d+)$")
-# Enterprise Plus predefined tiers (N2 / C4A), not Enterprise N4 customs.
-# Billing uses distinct Enterprise Plus SKUs.
+# Enterprise Plus predefined tiers (N2 / C4A).
+# Billing uses distinct Enterprise Plus SKUs, some meters label "C4", others "C4A".
 # https://cloud.google.com/skus/sku-groups/cloud-sql-cud-eligible-skus
+# https://cloud.google.com/skus/sku-groups/cloud-sql-enterprise-plus-compute
 _PG_ENTERPRISE_PLUS_N_MARKERS = ("perf-optimized", "memory-optimized")
-_PG_ENTERPRISE_PLUS_C4A_MARKERS = ("c4a",)
+_PG_ENTERPRISE_PLUS_C4A_MARKERS = ("c4a", "c4")
 _PG_ENTERPRISE_PLUS_FAMILIES = frozenset({"enterprise_plus_n", "enterprise_plus_c4a"})
 # https://cloud.google.com/sql/docs/postgres/faq
 _PG_SUPPORTED_MAJOR_VERSIONS = frozenset(
@@ -1146,6 +1146,9 @@ _PG_SUPPORTED_MAJOR_VERSIONS = frozenset(
 _PG_ENTERPRISE_PLUS_MAJOR_VERSIONS = frozenset(
     {"12", "13", "14", "15", "16", "17", "18"}
 )
+# C4A requires PostgreSQL 13+ (12 is unsupported on that machine series).
+# https://cloud.google.com/sql/docs/postgres/machine-series-overview
+_PG_ENTERPRISE_PLUS_C4A_MAJOR_VERSIONS = frozenset({"13", "14", "15", "16", "17", "18"})
 _PG_SHARED_TIERS = {"db-f1-micro": "f1-micro", "db-g1-small": "g1-small"}
 _PG_STORAGE_METERS = (
     (
@@ -1225,7 +1228,6 @@ _PG_TIER_FAMILY_LABELS = {
     "perf-optimized-N": "Performance Optimized N",
     "c4a-highmem": "C4A High Memory",
     "memory-optimized-N": "Memory Optimized N",
-    "custom": "Custom",
 }
 
 
@@ -1255,10 +1257,12 @@ def _pg_compute_sku_class(description: str) -> tuple[str, str] | None:
         return ("shared", match.group(1))
 
     extended = "Extended support" in description
-    # Match Plus / N4 before plain enterprise.
+    # Match Plus before plain enterprise. Billing may label C4A meters as "C4" or "C4A".
+    # Keep Enterprise N4 in its own family so those meters do not collide with
+    # general Enterprise vCPU/RAM (we do not catalog N4 custom tiers).
     if (
-        "Enterprise Plus Performance Optimized C4A" in description
-        or "Enterprise Plus C4A" in description
+        "Enterprise Plus Performance Optimized C4" in description
+        or "Enterprise Plus C4" in description
     ):
         family = "enterprise_plus_c4a"
     elif "Enterprise Plus N " in description:
@@ -1347,10 +1351,13 @@ def inventory_databases(vendor):
         if not tier_name:
             vendor.progress_tracker.advance_task()
             continue
+        # Skip custom shapes (db-custom-*), catalog predefined tiers only.
+        # https://cloud.google.com/sql/docs/postgres/machine-series-overview
+        if tier_name.startswith("db-custom-"):
+            vendor.progress_tracker.advance_task()
+            continue
 
-        if match := _PG_CUSTOM_TIER_RE.match(tier_name):
-            cpu_count = int(match.group(1))
-        elif match := _PG_NAMED_TIER_CPU_RE.search(tier_name):
+        if match := _PG_NAMED_TIER_CPU_RE.search(tier_name):
             cpu_count = int(match.group(1))
         else:
             cpu_count = None
@@ -1358,14 +1365,11 @@ def inventory_databases(vendor):
         ram_bytes = int(tier.get("RAM") or 0)
         memory_amount = int(ram_bytes / 1_048_576) if ram_bytes else None
 
-        if tier_name.startswith("db-custom-"):
-            family_slug = "custom"
-        else:
-            stripped = tier_name.removeprefix("db-")
-            parts = stripped.split("-")
-            family_slug = (
-                "-".join(parts[:-1]) if parts and parts[-1].isdigit() else stripped
-            )
+        stripped = tier_name.removeprefix("db-")
+        parts = stripped.split("-")
+        family_slug = (
+            "-".join(parts[:-1]) if parts and parts[-1].isdigit() else stripped
+        )
 
         spec_parts: list[str] = []
         if cpu_count is not None:
@@ -1410,7 +1414,13 @@ def inventory_databases(vendor):
             for version in meta["engine_versions"]
             if version in _PG_SUPPORTED_MAJOR_VERSIONS
         ]
-        if is_enterprise_plus:
+        if price_family == "enterprise_plus_c4a":
+            engine_versions = [
+                version
+                for version in engine_versions
+                if version in _PG_ENTERPRISE_PLUS_C4A_MAJOR_VERSIONS
+            ]
+        elif is_enterprise_plus:
             engine_versions = [
                 version
                 for version in engine_versions
@@ -1550,10 +1560,11 @@ def inventory_database_prices(vendor):
         if not tier_name:
             vendor.progress_tracker.advance_task()
             continue
+        if tier_name.startswith("db-custom-"):
+            vendor.progress_tracker.advance_task()
+            continue
 
-        if match := _PG_CUSTOM_TIER_RE.match(tier_name):
-            cpu_count = int(match.group(1))
-        elif match := _PG_NAMED_TIER_CPU_RE.search(tier_name):
+        if match := _PG_NAMED_TIER_CPU_RE.search(tier_name):
             cpu_count = int(match.group(1))
         else:
             cpu_count = None
@@ -1597,12 +1608,6 @@ def inventory_database_prices(vendor):
                     ram_sku = compute_index.get(
                         (region.api_reference, price_family, "ram", availability)
                     )
-                    # Enterprise N4 customs (if cataloged later) may lack a dedicated
-                    # RAM meter; Plus N / C4A have their own RAM SKUs.
-                    if ram_sku is None and price_family == "enterprise_n4":
-                        ram_sku = compute_index.get(
-                            (region.api_reference, "enterprise", "ram", availability)
-                        )
                     if vcpu_sku is not None and ram_sku is not None:
                         vcpu_hourly = _sku_unit_price(vcpu_sku)
                         ram_hourly = _sku_unit_price(ram_sku)

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -1231,6 +1231,8 @@ def _pg_sku_family(tier_name: str) -> str:
         return "shared"
     if tier_name.startswith("db-c4a-"):
         return "enterprise_plus_c4a"
+    if tier_name.startswith("db-perf-optimized-C4-"):
+        return "enterprise_plus_c4"
     if tier_name.startswith(_PG_PLUS_PREFIXES):
         return "enterprise_plus"
     return "enterprise"
@@ -1253,6 +1255,8 @@ def _pg_compute_sku_class(description: str) -> tuple[str, str] | None:
     extended = "Extended support" in description
     if "C4A" in description:
         family = "enterprise_plus_c4a"
+    elif "Enterprise Plus C4 " in description:
+        family = "enterprise_plus_c4"
     elif "Enterprise Plus" in description:
         family = "enterprise_plus"
     elif "Enterprise N4" in description:

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -1139,7 +1139,9 @@ _PG_NAMED_TIER_CPU_RE = recompile(r"-(\d+)$")
 _PG_ENTERPRISE_PLUS_N_MARKERS = ("perf-optimized", "memory-optimized")
 _PG_ENTERPRISE_PLUS_C4A_MARKERS = ("c4a", "c4")
 _PG_ENTERPRISE_PLUS_FAMILIES = frozenset({"enterprise_plus_n", "enterprise_plus_c4a"})
+# TODO: if PG19/PG20 become creatable, try using dynamic source again using _sqladmin_service().flags()
 # https://cloud.google.com/sql/docs/postgres/faq
+# https://docs.cloud.google.com/sql/docs/postgres/editions-intro
 _PG_SUPPORTED_MAJOR_VERSIONS = frozenset(
     {"9.6", "10", "11", "12", "13", "14", "15", "16", "17", "18"}
 )

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -1,5 +1,4 @@
 from concurrent.futures import ThreadPoolExecutor
-from datetime import timedelta
 from functools import cache
 from itertools import chain, repeat
 from logging import DEBUG
@@ -7,7 +6,7 @@ from re import compile as recompile
 from re import match, sub
 from typing import List
 
-from cachier import cachier, set_global_params
+from cachier import cachier
 from google.auth import default
 from google.cloud import billing_v1, compute_v1
 from googleapiclient.discovery import build
@@ -39,9 +38,6 @@ from ..vendor_helpers import (
     parallel_fetch_servers,
     preprocess_servers,
 )
-
-# set stale after to 1 day
-set_global_params(stale_after=timedelta(days=1))
 
 # ##############################################################################
 # Cached gcp client wrappers

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -1,4 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
 from functools import cache
 from itertools import chain, repeat
 from logging import DEBUG
@@ -6,7 +7,7 @@ from re import compile as recompile
 from re import match, sub
 from typing import List
 
-from cachier import cachier
+from cachier import cachier, set_global_params
 from google.auth import default
 from google.cloud import billing_v1, compute_v1
 from googleapiclient.discovery import build
@@ -38,6 +39,9 @@ from ..vendor_helpers import (
     parallel_fetch_servers,
     preprocess_servers,
 )
+
+# set stale after to 1 day
+set_global_params(stale_after=timedelta(days=1))
 
 # ##############################################################################
 # Cached gcp client wrappers
@@ -1219,6 +1223,7 @@ _PG_TIER_FAMILY_LABELS = {
     "n1-standard": "N1 Standard",
     "n1-highmem": "N1 High Memory",
     "perf-optimized-N": "Performance Optimized N",
+    "perf-optimized-C4": "Performance Optimized C4",
     "c4a-highmem": "C4A High Memory",
     "memory-optimized-N": "Memory Optimized N",
 }
@@ -1237,7 +1242,7 @@ def _pg_sku_family(tier_name: str) -> str:
 
 def _pg_compute_sku_class(description: str) -> tuple[str, str] | None:
     """Map a Cloud SQL Postgres compute SKU description to (price_family, component)."""
-    if "for Postgre" not in description:
+    if "for Postgre" not in description or "FDC Trial" in description:
         return None
     if "vCPU in" in description:
         component = "vcpu"

--- a/src/sc_crawler/vendors/_gcp.py
+++ b/src/sc_crawler/vendors/_gcp.py
@@ -1132,26 +1132,17 @@ def _cloud_sql_skus():
 
 
 _PG_NAMED_TIER_CPU_RE = recompile(r"-(\d+)$")
-# Enterprise Plus predefined tiers (N2 / C4A).
-# Billing uses distinct Enterprise Plus SKUs, some meters label "C4", others "C4A".
-# https://cloud.google.com/skus/sku-groups/cloud-sql-cud-eligible-skus
-# https://cloud.google.com/skus/sku-groups/cloud-sql-enterprise-plus-compute
-_PG_ENTERPRISE_PLUS_N_MARKERS = ("perf-optimized", "memory-optimized")
-_PG_ENTERPRISE_PLUS_C4A_MARKERS = ("c4a", "c4")
-_PG_ENTERPRISE_PLUS_FAMILIES = frozenset({"enterprise_plus_n", "enterprise_plus_c4a"})
 # TODO: if PG19/PG20 become creatable, try using dynamic source again using _sqladmin_service().flags()
 # https://cloud.google.com/sql/docs/postgres/faq
-# https://docs.cloud.google.com/sql/docs/postgres/editions-intro
 _PG_SUPPORTED_MAJOR_VERSIONS = frozenset(
     {"9.6", "10", "11", "12", "13", "14", "15", "16", "17", "18"}
 )
+# https://docs.cloud.google.com/sql/docs/postgres/editions-intro
 _PG_ENTERPRISE_PLUS_MAJOR_VERSIONS = frozenset(
     {"12", "13", "14", "15", "16", "17", "18"}
 )
-# C4A requires PostgreSQL 13+ (12 is unsupported on that machine series).
-# https://cloud.google.com/sql/docs/postgres/machine-series-overview
-_PG_ENTERPRISE_PLUS_C4A_MAJOR_VERSIONS = frozenset({"13", "14", "15", "16", "17", "18"})
 _PG_SHARED_TIERS = {"db-f1-micro": "f1-micro", "db-g1-small": "g1-small"}
+_PG_PLUS_PREFIXES = ("db-perf-optimized-", "db-memory-optimized-")
 _PG_STORAGE_METERS = (
     (
         recompile(r": Zonal - Enterprise Storage Hyperdisk Balanced Capacity in "),
@@ -1233,14 +1224,14 @@ _PG_TIER_FAMILY_LABELS = {
 }
 
 
-def _pg_tier_price_family(tier_name: str) -> str:
+def _pg_sku_family(tier_name: str) -> str:
+    """Billing-index family for a SQL Admin tier, keys match `_pg_compute_sku_class`."""
     if tier_name in _PG_SHARED_TIERS:
         return "shared"
-    lower = tier_name.lower()
-    if any(marker in lower for marker in _PG_ENTERPRISE_PLUS_C4A_MARKERS):
+    if tier_name.startswith("db-c4a-"):
         return "enterprise_plus_c4a"
-    if any(marker in lower for marker in _PG_ENTERPRISE_PLUS_N_MARKERS):
-        return "enterprise_plus_n"
+    if tier_name.startswith(_PG_PLUS_PREFIXES):
+        return "enterprise_plus"
     return "enterprise"
 
 
@@ -1259,16 +1250,10 @@ def _pg_compute_sku_class(description: str) -> tuple[str, str] | None:
         return ("shared", match.group(1))
 
     extended = "Extended support" in description
-    # Match Plus before plain enterprise. Billing may label C4A meters as "C4" or "C4A".
-    # Keep Enterprise N4 in its own family so those meters do not collide with
-    # general Enterprise vCPU/RAM (we do not catalog N4 custom tiers).
-    if (
-        "Enterprise Plus Performance Optimized C4" in description
-        or "Enterprise Plus C4" in description
-    ):
+    if "C4A" in description:
         family = "enterprise_plus_c4a"
-    elif "Enterprise Plus N " in description:
-        family = "enterprise_plus_n"
+    elif "Enterprise Plus" in description:
+        family = "enterprise_plus"
     elif "Enterprise N4" in description:
         family = "enterprise_n4"
     elif extended:
@@ -1408,25 +1393,21 @@ def inventory_databases(vendor):
         else:
             tier_regions = []
 
-        price_family = _pg_tier_price_family(tier_name)
-        is_enterprise_plus = price_family in _PG_ENTERPRISE_PLUS_FAMILIES
-        # Drop unreleased majors that flags.list may still advertise (e.g. 19).
+        sku_family = _pg_sku_family(tier_name)
+        is_enterprise_plus = sku_family.startswith("enterprise_plus")
         engine_versions = [
             version
             for version in meta["engine_versions"]
             if version in _PG_SUPPORTED_MAJOR_VERSIONS
         ]
-        if price_family == "enterprise_plus_c4a":
+        if is_enterprise_plus:
+            plus_versions = _PG_ENTERPRISE_PLUS_MAJOR_VERSIONS
+            if sku_family == "enterprise_plus_c4a":
+                # PostgreSQL 12 is unsupported on C4A only, not on N2 / C4.
+                # https://cloud.google.com/sql/docs/postgres/machine-series-overview
+                plus_versions = plus_versions - {"12"}
             engine_versions = [
-                version
-                for version in engine_versions
-                if version in _PG_ENTERPRISE_PLUS_C4A_MAJOR_VERSIONS
-            ]
-        elif is_enterprise_plus:
-            engine_versions = [
-                version
-                for version in engine_versions
-                if version in _PG_ENTERPRISE_PLUS_MAJOR_VERSIONS
+                version for version in engine_versions if version in plus_versions
             ]
 
         ha: list[DatabaseHaLevel] = []
@@ -1438,7 +1419,7 @@ def inventory_databases(vendor):
             # Zonal billing meters -> non-HA.
             # Enterprise Plus Advanced DR -> cross-region replica promotion (not multi-region HA).
             has_regional_ha = any(
-                (region, price_family) in ha_families for region in tier_regions
+                (region, sku_family) in ha_families for region in tier_regions
             )
             if has_regional_ha:
                 ha.append(DatabaseHaLevel.MULTI_ZONE)
@@ -1534,7 +1515,8 @@ def inventory_databases(vendor):
                     if is_enterprise_plus and has_regional_ha
                     else (
                         99.95
-                        if DatabaseHaLevel.MULTI_ZONE in ha and price_family != "shared"
+                        if DatabaseHaLevel.MULTI_ZONE in ha
+                        and tier_name not in _PG_SHARED_TIERS
                         else None
                     )
                 ),
@@ -1582,7 +1564,7 @@ def inventory_database_prices(vendor):
         else:
             tier_regions = set()
 
-        price_family = _pg_tier_price_family(tier_name)
+        sku_family = _pg_sku_family(tier_name)
         availabilities = ("zonal", "regional")
 
         for region in vendor.regions:
@@ -1591,7 +1573,7 @@ def inventory_database_prices(vendor):
 
             for availability in availabilities:
                 hourly = currency = None
-                if price_family == "shared":
+                if sku_family == "shared":
                     component = _PG_SHARED_TIERS[tier_name]
                     instance_sku = compute_index.get(
                         (region.api_reference, "shared", component, availability)
@@ -1605,10 +1587,10 @@ def inventory_database_prices(vendor):
                             currency = tiered[0].unit_price.currency_code or "USD"
                 elif cpu_count is not None and memory_gib is not None:
                     vcpu_sku = compute_index.get(
-                        (region.api_reference, price_family, "vcpu", availability)
+                        (region.api_reference, sku_family, "vcpu", availability)
                     )
                     ram_sku = compute_index.get(
-                        (region.api_reference, price_family, "ram", availability)
+                        (region.api_reference, sku_family, "ram", availability)
                     )
                     if vcpu_sku is not None and ram_sku is not None:
                         vcpu_hourly = _sku_unit_price(vcpu_sku)

--- a/src/sc_crawler/vendors/_ovh.py
+++ b/src/sc_crawler/vendors/_ovh.py
@@ -1074,18 +1074,18 @@ def inventory_databases(vendor):
         flavor_specs = flavor.get("specifications", {})
         vcpus = flavor_specs.get("core")
         memory = flavor_specs.get("memory", {}).get("value")
-        storage_size = flavor_specs.get("storage", {}).get("value")
+        # Do not use capabilities.flavors[].storage — that is the compute VM NVMe size
+        # (e.g. b3-16 = 100 GB), not DBaaS usable disk. Usable storage comes from
+        # availability specifications.storage.minimum / maximum (pricing: "From X GiB").
+        # https://www.ovhcloud.com/en/public-cloud/prices/
+        # https://docs.ovhcloud.com/en/guides/public-cloud/databases/postgresql-capabilities
         plan_label = plan.replace("-", " ").title()
-        spec_parts = [
-            f"{vcpus} vCPU{'s' if vcpus != 1 else ''}" if vcpus else None,
-            f"{memory} GB RAM" if memory else None,
-            f"{storage_size} GB SSD" if storage_size else None,
-        ]
 
         engine_versions: set[str] = set()
         ha: set[DatabaseHaLevel] = set()
         ha_strategy: set[DatabaseHaStrategy] = set()
         max_read_replicas = 0
+        storage_size = None
         storage_extra_max = None
         scheduled_backups = False
         continuous_backups = 0
@@ -1118,6 +1118,12 @@ def inventory_databases(vendor):
             max_read_replicas = max(max_read_replicas, max_nodes - 1)
             scheduled_backups = scheduled_backups or bool(scheduled)
             continuous_backups = max(continuous_backups, retention)
+            if storage_min is not None:
+                storage_size = (
+                    storage_min
+                    if storage_size is None
+                    else max(storage_size, storage_min)
+                )
             if (
                 storage_min is not None
                 and storage_max is not None
@@ -1153,6 +1159,11 @@ def inventory_databases(vendor):
                 sla = offer_sla if sla is None else max(sla, offer_sla)
 
         status = Status.best(offer_statuses) if offer_statuses else Status.INACTIVE
+        spec_parts = [
+            f"{vcpus} vCPU{'s' if vcpus != 1 else ''}" if vcpus else None,
+            f"{memory} GB RAM" if memory else None,
+            f"{storage_size} GB SSD" if storage_size else None,
+        ]
 
         items.append(
             {

--- a/src/sc_crawler/vendors/_upcloud.py
+++ b/src/sc_crawler/vendors/_upcloud.py
@@ -655,14 +655,21 @@ def inventory_databases(vendor):
         memory_amount = plan.get("memory_amount")
         components = plan.get("components", {})
         storage_component = components.get("storage", {})
-        # API sizes are MiB (same as memory_amount); schema storage fields use GB.
-        storage_size_gb = round(plan["storage_size"] / _MIB_PER_GIB * _GIB_TO_GB)
-        storage_step_gb = round(plan["storage_step_size"] / _MIB_PER_GIB * _GIB_TO_GB)
-        storage_extra_max_gb = round(
-            (plan["storage_cap_size"] - plan["storage_size"])
-            / _MIB_PER_GIB
-            * _GIB_TO_GB
+        # API `storage_size` / `included_gib` is cluster-total GiB; UI shows per-node GB.
+        # Store per-node integer GiB (do not apply decimal GiB→GB inflation).
+        # https://upcloud.com/docs/products/managed-postgresql/configurations/
+        nodes = node_count or 1
+        included_gib = storage_component.get("included_gib")
+        bundled_gib = (
+            int(included_gib)
+            if included_gib is not None
+            else plan["storage_size"] // _MIB_PER_GIB
         )
+        storage_size_gb = bundled_gib // nodes
+        storage_step_gb = plan["storage_step_size"] // _MIB_PER_GIB
+        storage_extra_max_gb = (
+            (plan["storage_cap_size"] - plan["storage_size"]) // _MIB_PER_GIB
+        ) // nodes
         dynamic_storage_supported = storage_component.get("dynamic_storage_supported")
         if dynamic_storage_supported:
             storage_extra_min = storage_step_gb

--- a/src/sc_crawler/vendors/_upcloud.py
+++ b/src/sc_crawler/vendors/_upcloud.py
@@ -655,8 +655,7 @@ def inventory_databases(vendor):
         memory_amount = plan.get("memory_amount")
         components = plan.get("components", {})
         storage_component = components.get("storage", {})
-        # API `storage_size` / `included_gib` is cluster-total GiB; UI shows per-node GB.
-        # Store per-node integer GiB (do not apply decimal GiB→GB inflation).
+        # UI/plan names say GB, but API values are GiB
         # https://upcloud.com/docs/products/managed-postgresql/configurations/
         nodes = node_count or 1
         included_gib = storage_component.get("included_gib")
@@ -665,11 +664,14 @@ def inventory_databases(vendor):
             if included_gib is not None
             else plan["storage_size"] // _MIB_PER_GIB
         )
-        storage_size_gb = bundled_gib // nodes
-        storage_step_gb = plan["storage_step_size"] // _MIB_PER_GIB
-        storage_extra_max_gb = (
-            (plan["storage_cap_size"] - plan["storage_size"]) // _MIB_PER_GIB
-        ) // nodes
+        storage_size_gb = round((bundled_gib // nodes) * _GIB_TO_GB)
+        storage_step_gb = round(
+            (plan["storage_step_size"] // _MIB_PER_GIB) * _GIB_TO_GB
+        )
+        storage_extra_max_gb = round(
+            ((plan["storage_cap_size"] - plan["storage_size"]) // _MIB_PER_GIB // nodes)
+            * _GIB_TO_GB
+        )
         dynamic_storage_supported = storage_component.get("dynamic_storage_supported")
         if dynamic_storage_supported:
             storage_extra_min = storage_step_gb
@@ -852,7 +854,7 @@ def inventory_database_storages(vendor):
     """List additional managed PostgreSQL disk as a single storage product.
 
     Extra disk is billed uniformly (`managed_database_tiered_storage_standard`) and
-    sold in 10 GiB steps up to 4x each plan's bundled storage.
+    sold in 10 GiB steps (stored as decimal GB) up to 4x each plan's bundled storage.
     https://upcloud.com/docs/changelog/2025-05-26-additional-disk-space-managed-databases/
     https://developers.upcloud.com/1.3/16-managed-database/
     """

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -55,7 +55,9 @@ from sc_crawler.vendors._azure import (
 )
 from sc_crawler.vendors._gcp import (
     _gcp_machine_type_status,
+    _pg_compute_sku_class,
     _pg_storage_id,
+    _pg_tier_price_family,
     inventory_database_prices,
     inventory_databases,
 )
@@ -604,6 +606,106 @@ def test_azure_inventory_databases_ha_from_supported_ha_mode():
     assert by_id["Standard_E2s_v3"]["status"] == Status.ACTIVE
 
 
+def test_azure_burstable_storage_extra_max_excludes_premium_ssd_v2():
+    from sc_crawler.utils import _GIB_TO_GB
+
+    vendor = Mock(vendor_id="azure")
+    vendor.regions = [Mock(region_id="centralus", api_reference="centralus")]
+    vendor.servers = []
+    vendor.progress_tracker = Mock(
+        start_task=Mock(), advance_task=Mock(), hide_task=Mock()
+    )
+    premium_ssd_max_mib = 32_767 * 1024
+    premium_ssd_v2_max_mib = 65_536 * 1024
+    capability = SimpleNamespace(
+        supported_server_versions=[SimpleNamespace(name="16", status="Available")],
+        storage_auto_growth_supported="Enabled",
+        supported_features=[],
+        supported_server_editions=[
+            SimpleNamespace(
+                name="Burstable",
+                supported_storage_editions=[
+                    SimpleNamespace(
+                        name="ManagedDisk",
+                        reason=None,
+                        supported_storage_mb=[
+                            SimpleNamespace(
+                                storage_size_mb=32 * 1024,
+                                maximum_storage_size_mb=premium_ssd_max_mib,
+                            )
+                        ],
+                    ),
+                    SimpleNamespace(
+                        name="ManagedDiskV2",
+                        reason=None,
+                        supported_storage_mb=[
+                            SimpleNamespace(
+                                storage_size_mb=32 * 1024,
+                                maximum_storage_size_mb=premium_ssd_v2_max_mib,
+                            )
+                        ],
+                    ),
+                ],
+                supported_server_skus=[
+                    SimpleNamespace(
+                        name="Standard_B2s",
+                        v_cores=2,
+                        supported_memory_per_vcore_mb=2048,
+                        supported_ha_mode=[],
+                    )
+                ],
+            ),
+            SimpleNamespace(
+                name="GeneralPurpose",
+                supported_storage_editions=[
+                    SimpleNamespace(
+                        name="ManagedDisk",
+                        reason=None,
+                        supported_storage_mb=[
+                            SimpleNamespace(
+                                storage_size_mb=32 * 1024,
+                                maximum_storage_size_mb=premium_ssd_max_mib,
+                            )
+                        ],
+                    ),
+                    SimpleNamespace(
+                        name="ManagedDiskV2",
+                        reason=None,
+                        supported_storage_mb=[
+                            SimpleNamespace(
+                                storage_size_mb=32 * 1024,
+                                maximum_storage_size_mb=premium_ssd_v2_max_mib,
+                            )
+                        ],
+                    ),
+                ],
+                supported_server_skus=[
+                    SimpleNamespace(
+                        name="Standard_D2s_v3",
+                        v_cores=2,
+                        supported_memory_per_vcore_mb=4096,
+                        supported_ha_mode=["SameZone"],
+                    )
+                ],
+            ),
+        ],
+    )
+    with (
+        patch(
+            "sc_crawler.vendors._azure._pg_database_regions",
+            return_value=vendor.regions,
+        ),
+        patch(
+            "sc_crawler.vendors._azure._pg_capabilities",
+            return_value=[capability],
+        ),
+    ):
+        rows = azure_databases(vendor)
+    by_id = {row["database_id"]: row for row in rows}
+    assert by_id["Standard_B2s"]["storage_extra_max"] == round(32_767 * _GIB_TO_GB)
+    assert by_id["Standard_D2s_v3"]["storage_extra_max"] == round(65_536 * _GIB_TO_GB)
+
+
 def test_azure_inventory_database_prices_emit_ha_rows():
     vendor = Mock(vendor_id="azure")
     vendor.regions = [Mock(region_id="centralus", api_reference="centralus")]
@@ -811,7 +913,7 @@ def test_gcp_inventory_databases_ha_uses_own_price_family_only():
         patch(
             "sc_crawler.vendors._gcp._pg_billing_catalog",
             # Only Enterprise Plus regional HA meters — must not imply Enterprise HA.
-            return_value=({}, frozenset({("us-central1", "enterprise_n4")})),
+            return_value=({}, frozenset({("us-central1", "enterprise_plus_n")})),
         ),
     ):
         rows = inventory_databases(vendor)
@@ -865,7 +967,7 @@ def test_gcp_inventory_databases_ha_multi_zone_from_regional_billing():
                 frozenset(
                     {
                         ("us-central1", "enterprise"),
-                        ("us-central1", "enterprise_n4"),
+                        ("us-central1", "enterprise_plus_n"),
                         ("us-central1", "shared"),
                     }
                 ),
@@ -874,6 +976,15 @@ def test_gcp_inventory_databases_ha_multi_zone_from_regional_billing():
     ):
         rows = inventory_databases(vendor)
     by_id = {row["database_id"]: row for row in rows}
+    assert by_id["db-n1-standard-4"]["ha"] == [
+        DatabaseHaLevel.MULTI_ZONE,
+        DatabaseHaLevel.NONE,
+    ]
+    assert by_id["db-n1-standard-4"]["ha_strategy"] == [
+        DatabaseHaStrategy.PASSIVE_STANDBY,
+        DatabaseHaStrategy.NONE,
+    ]
+    assert by_id["db-n1-standard-4"]["sla"] == 99.95
     assert by_id["db-perf-optimized-N-4"]["ha"] == [
         DatabaseHaLevel.MULTI_ZONE,
         DatabaseHaLevel.NONE,
@@ -893,16 +1004,110 @@ def test_gcp_inventory_databases_ha_multi_zone_from_regional_billing():
         DatabaseSecurityFeature.CUSTOMER_MANAGED_KEYS,
         DatabaseSecurityFeature.AUDIT_LOGGING,
     ]
-    assert by_id["db-n1-standard-4"]["ha"] == [
-        DatabaseHaLevel.MULTI_ZONE,
-        DatabaseHaLevel.NONE,
-    ]
     assert by_id["db-n1-standard-4"]["sla"] == 99.95
     assert by_id["db-f1-micro"]["ha"] == [
         DatabaseHaLevel.MULTI_ZONE,
         DatabaseHaLevel.NONE,
     ]
     assert by_id["db-f1-micro"]["sla"] is None
+
+
+def test_gcp_inventory_databases_filters_engine_versions_by_edition():
+    vendor = Mock(vendor_id="gcp")
+    vendor.regions = []
+    vendor.servers = []
+    vendor.progress_tracker = Mock(
+        start_task=Mock(), advance_task=Mock(), hide_task=Mock()
+    )
+    tiers = [
+        {
+            "tier": "db-f1-micro",
+            "RAM": "644245094",
+            "region": ["us-central1"],
+        },
+        {
+            "tier": "db-perf-optimized-N-8",
+            "RAM": str(64 * 1024**3),
+            "region": ["us-central1"],
+        },
+    ]
+    with (
+        patch(
+            "sc_crawler.vendors._gcp._pg_sqladmin_metadata",
+            return_value={
+                "tiers": tiers,
+                # flags.list can advertise unreleased majors; create-instance rejects 19.
+                "engine_versions": [
+                    "9.6",
+                    "10",
+                    "11",
+                    "12",
+                    "13",
+                    "14",
+                    "15",
+                    "16",
+                    "17",
+                    "18",
+                    "19",
+                ],
+                "custom_config": True,
+                "custom_extensions": True,
+            },
+        ),
+        patch(
+            "sc_crawler.vendors._gcp._pg_billing_catalog",
+            return_value=({}, frozenset()),
+        ),
+    ):
+        rows = inventory_databases(vendor)
+    by_id = {row["database_id"]: row for row in rows}
+    assert by_id["db-f1-micro"]["engine_versions"] == [
+        "9.6",
+        "10",
+        "11",
+        "12",
+        "13",
+        "14",
+        "15",
+        "16",
+        "17",
+        "18",
+    ]
+    assert by_id["db-perf-optimized-N-8"]["engine_versions"] == [
+        "12",
+        "13",
+        "14",
+        "15",
+        "16",
+        "17",
+        "18",
+    ]
+
+
+def test_gcp_compute_sku_class_and_tier_price_family():
+    assert _pg_tier_price_family("db-perf-optimized-N-4") == "enterprise_plus_n"
+    assert _pg_tier_price_family("db-memory-optimized-N-8") == "enterprise_plus_n"
+    assert _pg_tier_price_family("db-c4a-highmem-4") == "enterprise_plus_c4a"
+    assert _pg_tier_price_family("db-n1-standard-4") == "enterprise"
+    assert _pg_tier_price_family("db-f1-micro") == "shared"
+    assert _pg_compute_sku_class(
+        "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus N vCPU in Iowa"
+    ) == ("enterprise_plus_n", "vcpu")
+    assert _pg_compute_sku_class(
+        "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus N RAM in Iowa"
+    ) == ("enterprise_plus_n", "ram")
+    assert _pg_compute_sku_class(
+        "Cloud SQL for Postgres: Zonal - Enterprise Plus Performance Optimized C4A vCPU in Iowa"
+    ) == ("enterprise_plus_c4a", "vcpu")
+    assert _pg_compute_sku_class(
+        "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus C4A RAM in Iowa"
+    ) == ("enterprise_plus_c4a", "ram")
+    assert _pg_compute_sku_class(
+        "Cloud SQL for Postgres: Zonal - Enterprise N4 vCPU in Iowa"
+    ) == ("enterprise_n4", "vcpu")
+    assert _pg_compute_sku_class(
+        "Cloud SQL for PostgreSQL: Zonal - vCPU in Americas"
+    ) == ("enterprise", "vcpu")
 
 
 def test_gcp_inventory_databases_enterprise_plus_without_regional_ha():
@@ -1085,33 +1290,64 @@ def test_gcp_database_prices_use_region_name_not_numeric_id():
     assert prices[0]["ha_strategy"] == DatabaseHaStrategy.NONE
 
 
-def test_gcp_n4_family_prices_fall_back_to_enterprise_ram():
-    # Enterprise N4 vCPU + generic PostgreSQL RAM (no Enterprise N4 RAM SKU).
-    # 0.0542 * 4 + 0.0091 * 32 = 0.508
+def test_gcp_enterprise_plus_prices_use_plus_meters_not_enterprise_n4():
+    # Plus N: 0.0537 * 4 + 0.0091 * 32 = 0.506
+    # Plus C4A: 0.054 * 4 + 0.009 * 32 = 0.504
     skus = [
         _gcp_pg_sku(
-            "Cloud SQL for Postgres: Zonal - Enterprise N4 vCPU in Iowa",
+            "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus N vCPU in Iowa",
             regions=["us-central1"],
             units=0,
-            nanos=54_200_000,
+            nanos=53_700_000,
         ),
         _gcp_pg_sku(
-            "Cloud SQL for PostgreSQL: Zonal - RAM in Americas",
+            "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus N RAM in Iowa",
             regions=["us-central1"],
             units=0,
             nanos=9_100_000,
         ),
         _gcp_pg_sku(
-            "Cloud SQL for Postgres: Regional - Enterprise N4 vCPU in Iowa",
+            "Cloud SQL for PostgreSQL: Regional - Enterprise Plus N vCPU in Iowa",
             regions=["us-central1"],
             units=0,
-            nanos=108_400_000,
+            nanos=107_400_000,
         ),
         _gcp_pg_sku(
-            "Cloud SQL for PostgreSQL: Regional - RAM in Americas",
+            "Cloud SQL for PostgreSQL: Regional - Enterprise Plus N RAM in Iowa",
             regions=["us-central1"],
             units=0,
             nanos=18_200_000,
+        ),
+        _gcp_pg_sku(
+            "Cloud SQL for Postgres: Zonal - Enterprise Plus Performance Optimized C4A vCPU in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=54_000_000,
+        ),
+        _gcp_pg_sku(
+            "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus C4A RAM in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=9_000_000,
+        ),
+        _gcp_pg_sku(
+            "Cloud SQL for Postgres: Regional - Enterprise Plus Performance Optimized C4A vCPU in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=108_000_000,
+        ),
+        _gcp_pg_sku(
+            "Cloud SQL for PostgreSQL: Regional - Enterprise Plus C4A RAM in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=18_000_000,
+        ),
+        # Wrong meter for Plus tiers — must not be selected.
+        _gcp_pg_sku(
+            "Cloud SQL for Postgres: Zonal - Enterprise N4 vCPU in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=41_300_000,
         ),
     ]
     vendor = Mock(vendor_id="gcp")
@@ -1145,16 +1381,16 @@ def test_gcp_n4_family_prices_fall_back_to_enterprise_ram():
     ):
         prices = inventory_database_prices(vendor)
     by_id_ha = {(row["database_id"], row["ha"]): row for row in prices}
-    for database_id in (
-        "db-c4a-highmem-4",
-        "db-perf-optimized-N-4",
-        "db-memory-optimized-N-4",
-    ):
+    for database_id in ("db-perf-optimized-N-4", "db-memory-optimized-N-4"):
         zonal = by_id_ha[(database_id, DatabaseHaLevel.NONE)]
         regional = by_id_ha[(database_id, DatabaseHaLevel.MULTI_ZONE)]
-        assert abs(zonal["price"] - 0.508) < 0.001
-        assert abs(regional["price"] - 1.016) < 0.001
+        assert abs(zonal["price"] - 0.506) < 0.001
+        assert abs(regional["price"] - 1.012) < 0.001
         assert regional["ha_strategy"] == DatabaseHaStrategy.PASSIVE_STANDBY
+    c4a_zonal = by_id_ha[("db-c4a-highmem-4", DatabaseHaLevel.NONE)]
+    c4a_regional = by_id_ha[("db-c4a-highmem-4", DatabaseHaLevel.MULTI_ZONE)]
+    assert abs(c4a_zonal["price"] - 0.504) < 0.001
+    assert abs(c4a_regional["price"] - 1.008) < 0.001
 
 
 def test_gcp_database_prices_emit_regional_ha_rows():

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1030,6 +1030,11 @@ def test_gcp_inventory_databases_filters_engine_versions_by_edition():
             "RAM": str(64 * 1024**3),
             "region": ["us-central1"],
         },
+        {
+            "tier": "db-c4a-highmem-4",
+            "RAM": str(32 * 1024**3),
+            "region": ["us-central1"],
+        },
     ]
     with (
         patch(
@@ -1082,6 +1087,15 @@ def test_gcp_inventory_databases_filters_engine_versions_by_edition():
         "17",
         "18",
     ]
+    # C4A excludes PostgreSQL 12.
+    assert by_id["db-c4a-highmem-4"]["engine_versions"] == [
+        "13",
+        "14",
+        "15",
+        "16",
+        "17",
+        "18",
+    ]
 
 
 def test_gcp_compute_sku_class_and_tier_price_family():
@@ -1101,6 +1115,18 @@ def test_gcp_compute_sku_class_and_tier_price_family():
     ) == ("enterprise_plus_c4a", "vcpu")
     assert _pg_compute_sku_class(
         "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus C4A RAM in Iowa"
+    ) == ("enterprise_plus_c4a", "ram")
+    assert _pg_compute_sku_class(
+        "Cloud SQL for Postgres: Zonal - Enterprise Plus Performance Optimized C4 vCPU in Iowa"
+    ) == ("enterprise_plus_c4a", "vcpu")
+    assert _pg_compute_sku_class(
+        "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus C4 RAM in Iowa"
+    ) == ("enterprise_plus_c4a", "ram")
+    assert _pg_compute_sku_class(
+        "Cloud SQL for Postgres: Regional - Enterprise Plus Performance Optimized C4 vCPU in Iowa"
+    ) == ("enterprise_plus_c4a", "vcpu")
+    assert _pg_compute_sku_class(
+        "Cloud SQL for PostgreSQL: Regional - Enterprise Plus C4 RAM in Iowa"
     ) == ("enterprise_plus_c4a", "ram")
     assert _pg_compute_sku_class(
         "Cloud SQL for Postgres: Zonal - Enterprise N4 vCPU in Iowa"
@@ -1391,6 +1417,105 @@ def test_gcp_enterprise_plus_prices_use_plus_meters_not_enterprise_n4():
     c4a_regional = by_id_ha[("db-c4a-highmem-4", DatabaseHaLevel.MULTI_ZONE)]
     assert abs(c4a_zonal["price"] - 0.504) < 0.001
     assert abs(c4a_regional["price"] - 1.008) < 0.001
+
+
+def test_gcp_enterprise_plus_c4_label_meters_price_c4a_tiers():
+    # Billing SKU group also uses "C4" (without A) for the same Plus family.
+    skus = [
+        _gcp_pg_sku(
+            "Cloud SQL for Postgres: Zonal - Enterprise Plus Performance Optimized C4 vCPU in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=54_000_000,
+        ),
+        _gcp_pg_sku(
+            "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus C4 RAM in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=9_000_000,
+        ),
+        _gcp_pg_sku(
+            "Cloud SQL for Postgres: Regional - Enterprise Plus Performance Optimized C4 vCPU in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=108_000_000,
+        ),
+        _gcp_pg_sku(
+            "Cloud SQL for PostgreSQL: Regional - Enterprise Plus C4 RAM in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=18_000_000,
+        ),
+    ]
+    vendor = Mock(vendor_id="gcp")
+    vendor.regions = [Mock(region_id="1", api_reference="us-central1")]
+    vendor.progress_tracker = Mock(
+        start_task=Mock(), advance_task=Mock(), hide_task=Mock()
+    )
+    tiers = [
+        {
+            "tier": "db-c4a-highmem-4",
+            "RAM": str(32 * 1024**3),
+            "region": ["us-central1"],
+        },
+    ]
+    with (
+        patch("sc_crawler.vendors._gcp._cloud_sql_skus", return_value=skus),
+        patch(
+            "sc_crawler.vendors._gcp._pg_sqladmin_metadata",
+            return_value={"tiers": tiers},
+        ),
+    ):
+        prices = inventory_database_prices(vendor)
+    by_ha = {row["ha"]: row for row in prices}
+    assert abs(by_ha[DatabaseHaLevel.NONE]["price"] - 0.504) < 0.001
+    assert abs(by_ha[DatabaseHaLevel.MULTI_ZONE]["price"] - 1.008) < 0.001
+
+
+def test_gcp_inventory_skips_custom_tiers():
+    vendor = Mock(vendor_id="gcp")
+    vendor.regions = [Mock(region_id="1", api_reference="us-central1")]
+    vendor.servers = []
+    vendor.progress_tracker = Mock(
+        start_task=Mock(), advance_task=Mock(), hide_task=Mock()
+    )
+    tiers = [
+        {
+            "tier": "db-custom-N4-4-32768",
+            "RAM": str(32 * 1024**3),
+            "region": ["us-central1"],
+        },
+        {
+            "tier": "db-custom-4-16384",
+            "RAM": str(16 * 1024**3),
+            "region": ["us-central1"],
+        },
+        {
+            "tier": "db-n1-standard-4",
+            "RAM": str(15 * 1024**3),
+            "region": ["us-central1"],
+        },
+    ]
+    with (
+        patch(
+            "sc_crawler.vendors._gcp._pg_sqladmin_metadata",
+            return_value={
+                "tiers": tiers,
+                "engine_versions": ["16"],
+                "custom_config": True,
+                "custom_extensions": True,
+            },
+        ),
+        patch(
+            "sc_crawler.vendors._gcp._pg_billing_catalog",
+            return_value=({}, frozenset()),
+        ),
+        patch("sc_crawler.vendors._gcp._cloud_sql_skus", return_value=[]),
+    ):
+        databases = inventory_databases(vendor)
+        prices = inventory_database_prices(vendor)
+    assert [row["database_id"] for row in databases] == ["db-n1-standard-4"]
+    assert prices == []
 
 
 def test_gcp_database_prices_emit_regional_ha_rows():

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -244,17 +244,24 @@ def test_pg_storage_prices_skip_unsupported_retail_meters():
         start_task=Mock(), advance_task=Mock(), hide_task=Mock()
     )
     ultra_disk_retail = {
-        "productName": "Az DB for PostgreSQL Flexible Server Storage",
+        "productName": "Azure Database for PostgreSQL Flex Server Storage",
         "meterName": "Ultra Disk Storage Data Stored",
         "unitOfMeasure": "1 GB/Month",
         "retailPrice": "0.25",
         "currencyCode": "USD",
     }
     managed_disk_retail = {
-        "productName": "Az DB for PostgreSQL Flexible Server Storage",
+        "productName": "Azure Database for PostgreSQL Flex Server Storage",
         "meterName": "Storage Data Stored",
         "unitOfMeasure": "1 GB/Month",
         "retailPrice": "0.115",
+        "currencyCode": "USD",
+    }
+    managed_disk_v2_retail = {
+        "productName": "Az DB for PostgreSQL Flexible Server Storage",
+        "meterName": "Premium SSD v2 Storage Data Stored",
+        "unitOfMeasure": "1 GB/Month",
+        "retailPrice": "0.131",
         "currencyCode": "USD",
     }
     backup_retail = {
@@ -270,6 +277,10 @@ def test_pg_storage_prices_skip_unsupported_retail_meters():
                 supported_storage_editions=[
                     SimpleNamespace(
                         name="ManagedDisk",
+                        reason=None,
+                    ),
+                    SimpleNamespace(
+                        name="ManagedDiskV2",
                         reason=None,
                     ),
                     SimpleNamespace(
@@ -291,12 +302,17 @@ def test_pg_storage_prices_skip_unsupported_retail_meters():
         ),
         patch(
             "sc_crawler.vendors._azure._pg_retail_prices",
-            return_value=[ultra_disk_retail, managed_disk_retail, backup_retail],
+            return_value=[
+                ultra_disk_retail,
+                managed_disk_retail,
+                managed_disk_v2_retail,
+                backup_retail,
+            ],
         ),
     ):
         prices = azure_database_storage_prices(vendor)
     storage_ids = {row["database_storage_id"] for row in prices}
-    assert storage_ids == {"ManagedDisk", "BackupStorageLRS"}
+    assert storage_ids == {"ManagedDisk", "ManagedDiskV2", "BackupStorageLRS"}
 
 
 def test_pg_engine_versions_from_capability():

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -57,7 +57,6 @@ from sc_crawler.vendors._gcp import (
     _gcp_machine_type_status,
     _pg_compute_sku_class,
     _pg_storage_id,
-    _pg_tier_price_family,
     inventory_database_prices,
     inventory_databases,
 )
@@ -913,7 +912,7 @@ def test_gcp_inventory_databases_ha_uses_own_price_family_only():
         patch(
             "sc_crawler.vendors._gcp._pg_billing_catalog",
             # Only Enterprise Plus regional HA meters — must not imply Enterprise HA.
-            return_value=({}, frozenset({("us-central1", "enterprise_plus_n")})),
+            return_value=({}, frozenset({("us-central1", "enterprise_plus")})),
         ),
     ):
         rows = inventory_databases(vendor)
@@ -967,7 +966,7 @@ def test_gcp_inventory_databases_ha_multi_zone_from_regional_billing():
                 frozenset(
                     {
                         ("us-central1", "enterprise"),
-                        ("us-central1", "enterprise_plus_n"),
+                        ("us-central1", "enterprise_plus"),
                         ("us-central1", "shared"),
                     }
                 ),
@@ -1031,6 +1030,11 @@ def test_gcp_inventory_databases_filters_engine_versions_by_edition():
             "region": ["us-central1"],
         },
         {
+            "tier": "db-perf-optimized-C4-2",
+            "RAM": str(15 * 1024**3),
+            "region": ["us-central1"],
+        },
+        {
             "tier": "db-c4a-highmem-4",
             "RAM": str(32 * 1024**3),
             "region": ["us-central1"],
@@ -1087,7 +1091,16 @@ def test_gcp_inventory_databases_filters_engine_versions_by_edition():
         "17",
         "18",
     ]
-    # C4A excludes PostgreSQL 12.
+    # only C4A drops PostgreSQL 12
+    assert by_id["db-perf-optimized-C4-2"]["engine_versions"] == [
+        "12",
+        "13",
+        "14",
+        "15",
+        "16",
+        "17",
+        "18",
+    ]
     assert by_id["db-c4a-highmem-4"]["engine_versions"] == [
         "13",
         "14",
@@ -1098,35 +1111,18 @@ def test_gcp_inventory_databases_filters_engine_versions_by_edition():
     ]
 
 
-def test_gcp_compute_sku_class_and_tier_price_family():
-    assert _pg_tier_price_family("db-perf-optimized-N-4") == "enterprise_plus_n"
-    assert _pg_tier_price_family("db-memory-optimized-N-8") == "enterprise_plus_n"
-    assert _pg_tier_price_family("db-c4a-highmem-4") == "enterprise_plus_c4a"
-    assert _pg_tier_price_family("db-n1-standard-4") == "enterprise"
-    assert _pg_tier_price_family("db-f1-micro") == "shared"
+def test_gcp_compute_sku_class():
     assert _pg_compute_sku_class(
         "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus N vCPU in Iowa"
-    ) == ("enterprise_plus_n", "vcpu")
+    ) == ("enterprise_plus", "vcpu")
     assert _pg_compute_sku_class(
         "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus N RAM in Iowa"
-    ) == ("enterprise_plus_n", "ram")
+    ) == ("enterprise_plus", "ram")
     assert _pg_compute_sku_class(
         "Cloud SQL for Postgres: Zonal - Enterprise Plus Performance Optimized C4A vCPU in Iowa"
     ) == ("enterprise_plus_c4a", "vcpu")
     assert _pg_compute_sku_class(
         "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus C4A RAM in Iowa"
-    ) == ("enterprise_plus_c4a", "ram")
-    assert _pg_compute_sku_class(
-        "Cloud SQL for Postgres: Zonal - Enterprise Plus Performance Optimized C4 vCPU in Iowa"
-    ) == ("enterprise_plus_c4a", "vcpu")
-    assert _pg_compute_sku_class(
-        "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus C4 RAM in Iowa"
-    ) == ("enterprise_plus_c4a", "ram")
-    assert _pg_compute_sku_class(
-        "Cloud SQL for Postgres: Regional - Enterprise Plus Performance Optimized C4 vCPU in Iowa"
-    ) == ("enterprise_plus_c4a", "vcpu")
-    assert _pg_compute_sku_class(
-        "Cloud SQL for PostgreSQL: Regional - Enterprise Plus C4 RAM in Iowa"
     ) == ("enterprise_plus_c4a", "ram")
     assert _pg_compute_sku_class(
         "Cloud SQL for Postgres: Zonal - Enterprise N4 vCPU in Iowa"
@@ -1417,59 +1413,6 @@ def test_gcp_enterprise_plus_prices_use_plus_meters_not_enterprise_n4():
     c4a_regional = by_id_ha[("db-c4a-highmem-4", DatabaseHaLevel.MULTI_ZONE)]
     assert abs(c4a_zonal["price"] - 0.504) < 0.001
     assert abs(c4a_regional["price"] - 1.008) < 0.001
-
-
-def test_gcp_enterprise_plus_c4_label_meters_price_c4a_tiers():
-    # Billing SKU group also uses "C4" (without A) for the same Plus family.
-    skus = [
-        _gcp_pg_sku(
-            "Cloud SQL for Postgres: Zonal - Enterprise Plus Performance Optimized C4 vCPU in Iowa",
-            regions=["us-central1"],
-            units=0,
-            nanos=54_000_000,
-        ),
-        _gcp_pg_sku(
-            "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus C4 RAM in Iowa",
-            regions=["us-central1"],
-            units=0,
-            nanos=9_000_000,
-        ),
-        _gcp_pg_sku(
-            "Cloud SQL for Postgres: Regional - Enterprise Plus Performance Optimized C4 vCPU in Iowa",
-            regions=["us-central1"],
-            units=0,
-            nanos=108_000_000,
-        ),
-        _gcp_pg_sku(
-            "Cloud SQL for PostgreSQL: Regional - Enterprise Plus C4 RAM in Iowa",
-            regions=["us-central1"],
-            units=0,
-            nanos=18_000_000,
-        ),
-    ]
-    vendor = Mock(vendor_id="gcp")
-    vendor.regions = [Mock(region_id="1", api_reference="us-central1")]
-    vendor.progress_tracker = Mock(
-        start_task=Mock(), advance_task=Mock(), hide_task=Mock()
-    )
-    tiers = [
-        {
-            "tier": "db-c4a-highmem-4",
-            "RAM": str(32 * 1024**3),
-            "region": ["us-central1"],
-        },
-    ]
-    with (
-        patch("sc_crawler.vendors._gcp._cloud_sql_skus", return_value=skus),
-        patch(
-            "sc_crawler.vendors._gcp._pg_sqladmin_metadata",
-            return_value={"tiers": tiers},
-        ),
-    ):
-        prices = inventory_database_prices(vendor)
-    by_ha = {row["ha"]: row for row in prices}
-    assert abs(by_ha[DatabaseHaLevel.NONE]["price"] - 0.504) < 0.001
-    assert abs(by_ha[DatabaseHaLevel.MULTI_ZONE]["price"] - 1.008) < 0.001
 
 
 def test_gcp_inventory_skips_custom_tiers():

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1126,7 +1126,10 @@ def test_gcp_compute_sku_class():
     ) == ("enterprise_plus_c4a", "ram")
     assert _pg_compute_sku_class(
         "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus C4 vCPU in Johannesburg"
-    ) == ("enterprise_plus", "vcpu")
+    ) == ("enterprise_plus_c4", "vcpu")
+    assert _pg_compute_sku_class(
+        "Cloud SQL for PostgreSQL: Regional - Enterprise Plus C4 RAM in Johannesburg"
+    ) == ("enterprise_plus_c4", "ram")
     assert _pg_compute_sku_class(
         "Cloud SQL for Postgres: Zonal - Enterprise N4 vCPU in Iowa"
     ) == ("enterprise_n4", "vcpu")
@@ -1323,7 +1326,7 @@ def test_gcp_database_prices_use_region_name_not_numeric_id():
 
 def test_gcp_enterprise_plus_prices_use_plus_meters_not_enterprise_n4():
     # Plus N: 0.0537 * 4 + 0.0091 * 32 = 0.506
-    # Plus C4A: 0.054 * 4 + 0.009 * 32 = 0.504
+    # Plus C4 / C4A: 0.054 * 4 + 0.009 * 32 = 0.504
     skus = [
         _gcp_pg_sku(
             "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus N vCPU in Iowa",
@@ -1373,6 +1376,30 @@ def test_gcp_enterprise_plus_prices_use_plus_meters_not_enterprise_n4():
             units=0,
             nanos=18_000_000,
         ),
+        _gcp_pg_sku(
+            "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus C4 vCPU in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=54_000_000,
+        ),
+        _gcp_pg_sku(
+            "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus C4 RAM in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=9_000_000,
+        ),
+        _gcp_pg_sku(
+            "Cloud SQL for PostgreSQL: Regional - Enterprise Plus C4 vCPU in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=108_000_000,
+        ),
+        _gcp_pg_sku(
+            "Cloud SQL for PostgreSQL: Regional - Enterprise Plus C4 RAM in Iowa",
+            regions=["us-central1"],
+            units=0,
+            nanos=18_000_000,
+        ),
         # Wrong meter for Plus tiers — must not be selected.
         _gcp_pg_sku(
             "Cloud SQL for Postgres: Zonal - Enterprise N4 vCPU in Iowa",
@@ -1417,11 +1444,7 @@ def test_gcp_enterprise_plus_prices_use_plus_meters_not_enterprise_n4():
     ):
         prices = inventory_database_prices(vendor)
     by_id_ha = {(row["database_id"], row["ha"]): row for row in prices}
-    for database_id in (
-        "db-perf-optimized-N-4",
-        "db-memory-optimized-N-4",
-        "db-perf-optimized-C4-4",
-    ):
+    for database_id in ("db-perf-optimized-N-4", "db-memory-optimized-N-4"):
         zonal = by_id_ha[(database_id, DatabaseHaLevel.NONE)]
         regional = by_id_ha[(database_id, DatabaseHaLevel.MULTI_ZONE)]
         assert abs(zonal["price"] - 0.506) < 0.001
@@ -1431,6 +1454,10 @@ def test_gcp_enterprise_plus_prices_use_plus_meters_not_enterprise_n4():
     c4a_regional = by_id_ha[("db-c4a-highmem-4", DatabaseHaLevel.MULTI_ZONE)]
     assert abs(c4a_zonal["price"] - 0.504) < 0.001
     assert abs(c4a_regional["price"] - 1.008) < 0.001
+    c4_zonal = by_id_ha[("db-perf-optimized-C4-4", DatabaseHaLevel.NONE)]
+    c4_regional = by_id_ha[("db-perf-optimized-C4-4", DatabaseHaLevel.MULTI_ZONE)]
+    assert abs(c4_zonal["price"] - 0.504) < 0.001
+    assert abs(c4_regional["price"] - 1.008) < 0.001
 
 
 def test_gcp_inventory_skips_custom_tiers():

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1125,11 +1125,20 @@ def test_gcp_compute_sku_class():
         "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus C4A RAM in Iowa"
     ) == ("enterprise_plus_c4a", "ram")
     assert _pg_compute_sku_class(
+        "Cloud SQL for PostgreSQL: Zonal - Enterprise Plus C4 vCPU in Johannesburg"
+    ) == ("enterprise_plus", "vcpu")
+    assert _pg_compute_sku_class(
         "Cloud SQL for Postgres: Zonal - Enterprise N4 vCPU in Iowa"
     ) == ("enterprise_n4", "vcpu")
     assert _pg_compute_sku_class(
         "Cloud SQL for PostgreSQL: Zonal - vCPU in Americas"
     ) == ("enterprise", "vcpu")
+    assert (
+        _pg_compute_sku_class(
+            "FDC Trial in Cloud SQL for PostgreSQL: Zonal - vCPU in Mexico"
+        )
+        is None
+    )
 
 
 def test_gcp_inventory_databases_enterprise_plus_without_regional_ha():
@@ -1393,6 +1402,11 @@ def test_gcp_enterprise_plus_prices_use_plus_meters_not_enterprise_n4():
             "RAM": str(32 * 1024**3),
             "region": ["us-central1"],
         },
+        {
+            "tier": "db-perf-optimized-C4-4",
+            "RAM": str(32 * 1024**3),
+            "region": ["us-central1"],
+        },
     ]
     with (
         patch("sc_crawler.vendors._gcp._cloud_sql_skus", return_value=skus),
@@ -1403,7 +1417,11 @@ def test_gcp_enterprise_plus_prices_use_plus_meters_not_enterprise_n4():
     ):
         prices = inventory_database_prices(vendor)
     by_id_ha = {(row["database_id"], row["ha"]): row for row in prices}
-    for database_id in ("db-perf-optimized-N-4", "db-memory-optimized-N-4"):
+    for database_id in (
+        "db-perf-optimized-N-4",
+        "db-memory-optimized-N-4",
+        "db-perf-optimized-C4-4",
+    ):
         zonal = by_id_ha[(database_id, DatabaseHaLevel.NONE)]
         regional = by_id_ha[(database_id, DatabaseHaLevel.MULTI_ZONE)]
         assert abs(zonal["price"] - 0.506) < 0.001

--- a/tests/test_ovh.py
+++ b/tests/test_ovh.py
@@ -539,6 +539,51 @@ def test_inventory_databases_collapses_versions_and_maps_fields(mock_ovh_client)
     assert retired["status"] == Status.RETIRED
 
 
+def test_inventory_databases_uses_availability_storage_not_flavor_nvme(mock_ovh_client):
+    # capabilities.flavors[].storage is compute NVMe (100 GB for b3-16); DBaaS usable
+    # disk is availability specifications.storage.minimum (320 GiB on pricing page).
+    capabilities = {
+        "engines": [
+            {"name": "postgresql", "versions": ["16"], "sslModes": ["required"]}
+        ],
+        "flavors": [
+            {
+                "name": "b3-16",
+                "core": 4,
+                "memory": 16,
+                "storage": 100,
+                "generation": "gen3",
+                "specifications": {
+                    "core": 4,
+                    "memory": {"unit": "GB", "value": 16},
+                    "storage": {"unit": "GB", "value": 100},
+                },
+            }
+        ],
+        "plans": [{"name": "production", "backupRetention": "P14D"}],
+    }
+    _extend_ovh_get(
+        mock_ovh_client,
+        availability=[
+            _pg_offer(
+                flavor="b3-16",
+                min_disk=320,
+                max_disk=1600,
+            )
+        ],
+        capabilities=capabilities,
+        catalog_addons=[],
+    )
+    vendor = _ovh_vendor(
+        servers=[SimpleNamespace(server_id="b3-16", api_reference="b3-16")]
+    )
+    rows = inventory_databases(vendor)
+    assert len(rows) == 1
+    assert rows[0]["database_id"] == "postgresql-production-b3-16"
+    assert rows[0]["storage_size"] == 320
+    assert rows[0]["storage_extra_max"] == 1280
+
+
 def test_inventory_databases_merges_multi_az_ha(mock_ovh_client):
     availability = [
         _pg_offer(region="GRA", version="16"),

--- a/tests/test_upcloud.py
+++ b/tests/test_upcloud.py
@@ -146,17 +146,16 @@ def test_upcloud_inventory_databases_maps_pg_service_plans():
     assert by_id["2xCPU-4GB-50GB"]["scheduled_backups"] is True
     assert by_id["2xCPU-4GB-50GB"]["continuous_backups"] == 7
     assert by_id["2xCPU-4GB-50GB"]["memory_amount"] == 4096
-    assert by_id["2xCPU-4GB-50GB"]["storage_extra_min"] == round(
-        10240 / 1024 * _GIB_TO_GB
-    )
-    assert by_id["2xCPU-4GB-50GB"]["storage_extra_max"] == round(
-        (204800 - 51200) / 1024 * _GIB_TO_GB
-    )
+    assert by_id["2xCPU-4GB-50GB"]["storage_size"] == 50
+    assert by_id["2xCPU-4GB-50GB"]["storage_extra_min"] == 10
+    assert by_id["2xCPU-4GB-50GB"]["storage_extra_max"] == 150
     assert by_id["2xCPU-4GB-50GB"]["connection_pool"] is True
     assert by_id["2xCPU-4GB-50GB"]["sla"] == 99.999
     assert by_id["2xCPU-4GB-50GB"]["status"] == Status.ACTIVE
     assert by_id["4xCPU-16GB-200GB-ha"]["family"] == "2-node HA"
     assert by_id["4xCPU-16GB-200GB-ha"]["server_id"] == "4xCPU-16GB"
+    assert by_id["4xCPU-16GB-200GB-ha"]["storage_size"] == 100
+    assert by_id["4xCPU-16GB-200GB-ha"]["storage_extra_max"] == 300
     assert by_id["4xCPU-16GB-200GB-ha"]["ha"] == [DatabaseHaLevel.SINGLE_ZONE]
     assert by_id["4xCPU-16GB-200GB-ha"]["ha_strategy"] == [
         DatabaseHaStrategy.READABLE_CLUSTER

--- a/tests/test_upcloud.py
+++ b/tests/test_upcloud.py
@@ -146,16 +146,18 @@ def test_upcloud_inventory_databases_maps_pg_service_plans():
     assert by_id["2xCPU-4GB-50GB"]["scheduled_backups"] is True
     assert by_id["2xCPU-4GB-50GB"]["continuous_backups"] == 7
     assert by_id["2xCPU-4GB-50GB"]["memory_amount"] == 4096
-    assert by_id["2xCPU-4GB-50GB"]["storage_size"] == 50
-    assert by_id["2xCPU-4GB-50GB"]["storage_extra_min"] == 10
-    assert by_id["2xCPU-4GB-50GB"]["storage_extra_max"] == 150
+    # 50 GiB / 150 GiB extra / 10 GiB step → decimal GB.
+    assert by_id["2xCPU-4GB-50GB"]["storage_size"] == round(50 * _GIB_TO_GB)
+    assert by_id["2xCPU-4GB-50GB"]["storage_extra_min"] == round(10 * _GIB_TO_GB)
+    assert by_id["2xCPU-4GB-50GB"]["storage_extra_max"] == round(150 * _GIB_TO_GB)
     assert by_id["2xCPU-4GB-50GB"]["connection_pool"] is True
     assert by_id["2xCPU-4GB-50GB"]["sla"] == 99.999
     assert by_id["2xCPU-4GB-50GB"]["status"] == Status.ACTIVE
     assert by_id["4xCPU-16GB-200GB-ha"]["family"] == "2-node HA"
     assert by_id["4xCPU-16GB-200GB-ha"]["server_id"] == "4xCPU-16GB"
-    assert by_id["4xCPU-16GB-200GB-ha"]["storage_size"] == 100
-    assert by_id["4xCPU-16GB-200GB-ha"]["storage_extra_max"] == 300
+    # Cluster 200 GiB / 2 nodes = 100 GiB per node → decimal GB.
+    assert by_id["4xCPU-16GB-200GB-ha"]["storage_size"] == round(100 * _GIB_TO_GB)
+    assert by_id["4xCPU-16GB-200GB-ha"]["storage_extra_max"] == round(300 * _GIB_TO_GB)
     assert by_id["4xCPU-16GB-200GB-ha"]["ha"] == [DatabaseHaLevel.SINGLE_ZONE]
     assert by_id["4xCPU-16GB-200GB-ha"]["ha_strategy"] == [
         DatabaseHaStrategy.READABLE_CLUSTER


### PR DESCRIPTION
# Overview

- `GCP`: map Enterprise Plus (N / C4A) instances correctly, drop unsupported PG19
- `Azure`: 
  - cap Burstable extra storage (exclude Premium SSD v2 / unsupported editions)
  - restore Flexible Server data-storage prices after the Retail product rename to Flex Server Storage
- `UpCloud`: store storage as per-node GiB (fixes multi-node dump vs UI)
- `OVH`: Use availability usable disk min, not compute flavor NVMe size

Note: we don't store custom tiers at `GCP` and `UpCloud`.

Extra: fix caching behaviour.

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added improved Google Cloud SQL Enterprise Plus tier classification, pricing, and edition-specific PostgreSQL version support.
  - Improved database storage sizing for Azure, OVH, and UpCloud using provider-specific capacity details.

- **Bug Fixes**
  - Excluded unsupported Azure storage options and custom Google Cloud tiers from inventory and pricing calculations.
  - Corrected OVH storage capacity calculations and UpCloud values to use decimal GB conversions.

- **Tests**
  - Expanded coverage for cloud pricing, storage sizing, edition filtering, and regression scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->