### PR TITLE
Update Azure lifecycle rules

### DIFF
--- a/src/sc_crawler/vendors/_azure.py
+++ b/src/sc_crawler/vendors/_azure.py
@@ -301,18 +301,26 @@ STORAGE_PRICE_UNIT_MAPPING: dict[str, float | None] = {
 }
 """Storage capacity units → multiplier to convert the raw API price to $/GB/month."""
 
-# VM size series lifecycle. Previous-gen is not retirement.
+# VM size series lifecycle. Previous-gen without a retirement date stays ACTIVE
+# (Dv3/Dsv3, Ev3/Esv3, Ev4/Esv4, Eav4/Easv4, Edv4/Edsv4, Preview DC).
 # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retired-sizes-list
 # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/previous-gen-sizes-list
-# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/d-ds-dv2-dsv2-ls-series-migration-guide
-# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/nvv4-retirement
-# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/hbv2-series-retirement
-# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/hc-series-retirement
-# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/dcsv2-series-retirement
-# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/n-series-migration
 # https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/av1-series-retirement
-# Rule format: (compiled regex or exact size, retired_on date or None).
-# - If retired_on is set and as_of >= retired_on -> RETIRED.
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/n-series-migration
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/ncv3-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/dcsv2-series-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/retirement/dcsv3-series-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/dcccv5-series-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/ecccv5-series-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/d-ds-dv2-dsv2-ls-series-migration-guide
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/nvv3-series-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/nvv4-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/np-series-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/hc-series-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/hbv2-series-retirement
+# https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/lifecycle/retirement/msv2-mdsv2-retirement
+# Rule format: (compiled regex, retired_on date).
+# - If as_of >= retired_on -> RETIRED.
 # - Else matched -> PLANNED_FOR_RETIREMENT.
 # - No match -> ACTIVE.
 _AZURE_SKU_LIFECYCLE_RULES = (
@@ -321,11 +329,14 @@ _AZURE_SKU_LIFECYCLE_RULES = (
     (recompile(r"^NC\d+r?s_v2$", IGNORECASE), date(2023, 8, 31)),  # NCv2-series
     (recompile(r"^ND\d+r?s?$", IGNORECASE), date(2023, 8, 31)),  # ND v1-series
     (recompile(r"^DC\d+s?_v2$", IGNORECASE), date(2026, 6, 30)),  # DCsv2-series
+    (recompile(r"^DC\d+d?s_v3$", IGNORECASE), date(2029, 10, 31)),  # noqa: E501  # DCsv3/DCdsv3-series
+    (recompile(r"^DC\d+a[d]?s_cc_v5$", IGNORECASE), date(2026, 9, 1)),  # noqa: E501  # DCas/DCads_cc_v5
+    (recompile(r"^EC\d+a[d]?s_cc_v5$", IGNORECASE), date(2026, 9, 1)),  # noqa: E501  # ECas/ECads_cc_v5
     (recompile(r"^NC(?:6s|12s|24s|24rs)_v3$", IGNORECASE), date(2025, 9, 30)),  # noqa: E501  # NCv3-series
     (recompile(r"^D\d+(-\d+)?$", IGNORECASE), date(2028, 5, 1)),  # D-series
     (recompile(r"^DS\d+(-\d+)?$", IGNORECASE), date(2028, 5, 1)),  # Ds-series
-    (recompile(r"^D\d+(-\d+)?_v2$", IGNORECASE), date(2028, 5, 1)),  # Dv2-series
-    (recompile(r"^DS\d+(-\d+)?_v2$", IGNORECASE), date(2028, 5, 1)),  # Dsv2-series
+    (recompile(r"^D\d+(-\d+)?_v2$", IGNORECASE), date(2028, 5, 1)),  # noqa: E501  # Dv2-series (incl. memory D11-D15)
+    (recompile(r"^DS\d+(-\d+)?_v2$", IGNORECASE), date(2028, 5, 1)),  # noqa: E501  # Dsv2-series (incl. memory DS11-DS15)
     (recompile(r"^L\d+s$", IGNORECASE), date(2028, 5, 1)),  # Ls-series
     (recompile(r"^A\d+_v2$", IGNORECASE), date(2028, 11, 15)),  # Av2-series
     (recompile(r"^A\d+m_v2$", IGNORECASE), date(2028, 11, 15)),  # Amv2-series
@@ -336,12 +347,12 @@ _AZURE_SKU_LIFECYCLE_RULES = (
     (recompile(r"^G\d+$", IGNORECASE), date(2028, 11, 15)),  # G-series
     (recompile(r"^GS\d+(-\d+)?$", IGNORECASE), date(2028, 11, 15)),  # Gs-series
     (recompile(r"^L\d+s_v2$", IGNORECASE), date(2028, 11, 15)),  # Lsv2-series
-    (recompile(r"^NV\d+s_v3$", IGNORECASE), date(2026, 9, 30)),  # NVv3-series
+    (recompile(r"^NV\d+s_v3$", IGNORECASE), date(2026, 9, 30)),  # noqa: E501  # NVv3-series (M60), not NCasT4_v3
     (recompile(r"^NV\d+a[h]?s_v4$", IGNORECASE), date(2026, 9, 30)),  # NVv4-series
     (recompile(r"^NP\d+s$", IGNORECASE), date(2027, 5, 31)),  # NP-series
     (recompile(r"^HC44(-\d+)?rs$", IGNORECASE), date(2027, 5, 31)),  # HC-series
     (recompile(r"^HB120(-\d+)?rs_v2$", IGNORECASE), date(2027, 5, 31)),  # HBv2-series
-    (recompile(r"^M192i(?:dm?|m)?s_v2$", IGNORECASE), date(2027, 3, 31)),  # noqa: E501  # Mv2 isolated sizes
+    (recompile(r"^M192i(?:dm?|m)?s_v2$", IGNORECASE), date(2027, 3, 31)),  # noqa: E501  # Msv2/Mdsv2 isolated
 )
 
 

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -350,8 +350,15 @@ def test_azure_sku_lifecycle_status_from_retired_sizes_list():
         "Standard_NP10s",
         "Standard_HC44rs",
         "Standard_HC44-16rs",
+        "Standard_HB120rs_v2",
         "Standard_M192ims_v2",
         "Standard_M192ids_v2",
+        "Standard_DC2s_v3",
+        "Standard_DC8ds_v3",
+        "Standard_DC4as_cc_v5",
+        "Standard_DC8ads_cc_v5",
+        "Standard_EC4as_cc_v5",
+        "Standard_EC4ads_cc_v5",
     ]
     retired = [
         "Standard_A2",
@@ -369,6 +376,8 @@ def test_azure_sku_lifecycle_status_from_retired_sizes_list():
         "Standard_D4s_v5",
         "Standard_B2als_v2",
         "Standard_E2s_v3",
+        "Standard_E4s_v3",
+        "Standard_DC4as_v5",
         "Standard_L8s_v3",
         "Standard_NC4as_T4_v3",
         "Standard_NV4ads_V710_v5",
@@ -430,6 +439,24 @@ def test_azure_sku_lifecycle_status_transitions_on_retirement_date():
     )
     assert (
         _azure_sku_lifecycle_status("Standard_NP10s", as_of=date(2027, 5, 31))
+        == Status.RETIRED
+    )
+    # DCas_cc_v5 / ECas_cc_v5: retires 2026-09-01
+    assert (
+        _azure_sku_lifecycle_status("Standard_DC4as_cc_v5", as_of=date(2026, 8, 31))
+        == Status.PLANNED_FOR_RETIREMENT
+    )
+    assert (
+        _azure_sku_lifecycle_status("Standard_DC4as_cc_v5", as_of=date(2026, 9, 1))
+        == Status.RETIRED
+    )
+    # DCsv3 / DCdsv3: retires 2029-10-31
+    assert (
+        _azure_sku_lifecycle_status("Standard_DC2s_v3", as_of=date(2029, 10, 30))
+        == Status.PLANNED_FOR_RETIREMENT
+    )
+    assert (
+        _azure_sku_lifecycle_status("Standard_DC8ds_v3", as_of=date(2029, 10, 31))
         == Status.RETIRED
     )
 


### PR DESCRIPTION
# Overview

Update Azure lifecycle rules.

# Required checks before merge

Mark all tasks that were completed with a checkmark. Unrelated tasks can be left unchecked.

PR status:

- [ ] Branch is based on and up-to-date with `main`
- [ ] PR has a clear title and/or brief description
- [ ] PR builders passed
- [ ] No red flags from coderabbit.ai
- [ ] Pinged code owners for human review after all other major items in this list are completed
- [ ] Human approval

Versioning, changelog, and documentation:

- [ ] New features, bugfixes etc are tracked in `CHANGELOG.md`
- [ ] Package version bumped in `pyproject.toml`
- [ ] `add_vendor.md` is up-to-date (after schema changes or new learnings that generalizes well to future vendors)
- [ ] `mkdocs` renders correctly in local preview and has been manually checked on new or updated functions/methods


Database:

- [ ] Alembic migrations are provided for database schema changes
    - [ ] Tested on SQLite
    - [ ] Tested on PostgreSQL
- [ ] `sc-crawler pull` was tested on all vendors and records
- [ ] Data changes were manually cross-checked with the vendor homepages or other trusted sources
- [ ] The output (e.g. SQLite file) of an example run is included in the PR to demonstrate major data changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Azure SKU lifecycle tracking with retirement dates for additional DCsv3/DCdsv3, DCas/DCads CC v5, and ECas/ECads CC v5 series.
  * Clarified lifecycle handling for previous-generation Azure SKUs without announced retirement dates, which remain active.
  * Improved lifecycle coverage for newly announced retirement and active SKU statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->